### PR TITLE
Counterfactual simulation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # CounterfactualCovid19
 Repository for the Leeds-Turing project for simulating a counterfactual history of the growth of COVID-19 cases in Europe
+
+
+# Installation
+
+This package requires Python 3.6 or greater. To install, start by creating a fresh conda environment.
+```
+conda create -n counterfactual python=3.7
+conda activate counterfactual
+```
+
+Get the source.
+```
+git clone https://github.com/alan-turing-institute/CounterfactualCovid19.git
+```
+
+Enter the repository and check out a relevant branch if necessary (the develop branch contains the most up to date stable version of the code).
+```
+cd CounterfactualCovid19
+git checkout develop
+```
+Install the package using `pip`.
+```
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+matplotlib
+seaborn
+pytest
+pandas
+scipy

--- a/src/process_data.py
+++ b/src/process_data.py
@@ -1,0 +1,73 @@
+import pandas as pd
+
+
+def get_natural_history_data(country, df_cases):
+    """
+
+    Parameters
+    ----------
+    country: str
+        Country for data to be fetched
+    df_cases: dataframe
+        Historical case data.
+
+    Returns
+    -------
+     Two time series with the data from daily and cumulative cases.
+
+
+    """
+
+    # select country
+    data_country_daily = df_cases[df_cases['Country'] == country]
+    data_country_cum = df_cases[df_cases['Country'] == country]
+
+    # reindex with date
+    data_country_daily.set_index('Date', inplace=True)
+    data_country_cum.set_index('Date', inplace=True)
+
+    # get time series
+    data_country_daily = data_country_daily['Daily_cases_MA7']
+    data_country_cum = data_country_cum['Cumulative_cases_end_MA7']
+
+    return data_country_daily, data_country_cum
+
+
+def get_important_dates(country, df_summaries):
+    """
+    For a given country get important dates for the simulation and data visualisation
+
+    Parameters
+    ----------
+    country: str
+        Country for data to be fetched
+    df_summaries: dataframe
+        Dates and restrictions applied for each country
+
+    Returns
+    -------
+
+    """
+    summary_eur_country = df_summaries[df_summaries["Country"] == country]
+
+    dates_dict = {}
+
+    # Record important dates
+    # date for which cumulative cases first exceeded this percent (Date_pop_pct)
+    dates_dict['initial_date'] = pd.to_datetime(summary_eur_country.Date_pop_pct, format="%Y-%m-%d")
+
+
+
+    # lastdate to include data
+    # Date_max, Date_restrictions_eased + 28, or Date_lockdown_eased + 28, whichever comes first
+    dates_dict['maximum_date'] = pd.to_datetime(summary_eur_country.Date_T, format="%Y-%m-%d")
+    dates_dict['date_first_restriction'] = summary_eur_country.Date_first_restriction
+
+    dates_dict['date_lockdown'] = summary_eur_country.Date_lockdown
+
+    return dates_dict
+
+
+
+
+

--- a/src/process_data.py
+++ b/src/process_data.py
@@ -46,6 +46,7 @@ def get_important_dates(country, df_summaries):
 
     Returns
     -------
+    Dictionary with datetime objects of the main restriction dates for a country
 
     """
     summary_eur_country = df_summaries[df_summaries["Country"] == country]
@@ -54,18 +55,52 @@ def get_important_dates(country, df_summaries):
 
     # Record important dates
     # date for which cumulative cases first exceeded this percent (Date_pop_pct)
-    dates_dict['initial_date'] = pd.to_datetime(summary_eur_country.Date_pop_pct, format="%Y-%m-%d")
+    dates_dict['initial_date'] = pd.to_datetime(summary_eur_country.Date_pop_pct.values[0], format="%Y-%m-%d")
 
 
 
     # lastdate to include data
     # Date_max, Date_restrictions_eased + 28, or Date_lockdown_eased + 28, whichever comes first
-    dates_dict['maximum_date'] = pd.to_datetime(summary_eur_country.Date_T, format="%Y-%m-%d")
-    dates_dict['date_first_restriction'] = summary_eur_country.Date_first_restriction
+    dates_dict['maximum_date'] = pd.to_datetime(summary_eur_country.Date_T.values[0], format="%Y-%m-%d")
+    dates_dict['date_first_restriction'] = pd.to_datetime(summary_eur_country.Date_first_restriction.values[0], format="%Y-%m-%d")
 
-    dates_dict['date_lockdown'] = summary_eur_country.Date_lockdown
+    dates_dict['date_lockdown'] = pd.to_datetime(summary_eur_country.Date_lockdown.values[0], format="%Y-%m-%d")
 
     return dates_dict
+
+def get_number_of_cases(country, df_cases, date):
+    """
+    Get initial number of cases for a given country and a given date
+
+    Parameters
+    ----------
+    country: str
+        Country for data to be fetched
+    df_cases: dataframe
+        Historical case data.
+    date: datetime object
+        Date to extract case numbers
+
+    Returns
+    -------
+    Initial case number for that date and initial cumulative case number
+
+    """
+
+    data_eur_country = df_cases[df_cases['Country'] == country]
+    data_eur_country['Date'] = pd.to_datetime(data_eur_country['Date'])
+
+    # get initial number of cases for the first day of the simulation
+    initial_case_number = data_eur_country[data_eur_country['Date'] == (date - pd.Timedelta(days=1))][
+        'Daily_cases_MA7'].values[0]
+
+    # get initial cumulative number of cases for the first day of the simulation
+    initial_cumulative_case_number = \
+    data_eur_country[data_eur_country['Date'] == (date - pd.Timedelta(days=1))][
+        'Cumulative_cases_end_MA7'].values[0]
+
+    return initial_case_number, initial_cumulative_case_number
+
 
 
 

--- a/src/simulate_counterfactuals.py
+++ b/src/simulate_counterfactuals.py
@@ -1,0 +1,42 @@
+import pandas
+
+
+def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots_points, df_summaries):
+    """
+    Function that simulates the evolution of Covi19 cases for a country, given a shift in the time
+    the restrictions where applied.
+
+    Parameters
+    ----------
+    country: str
+        Country to be simulated
+    restrictions_shifts: int
+        Number of days earlier to implement FIRST RESTRICTION and LOCKDOWN
+    df_cases: dataframe
+        Historical case data.
+    best_knots_points: dataframe
+        Different growth periods for each country
+    df_summaries: dataframe
+        Dates and restrictions applied for each country
+
+    Returns
+    -------
+    A time series with the simulated daily cases.
+
+    """
+
+    # Filter datasets by country
+    knots_best_country = best_knots_points[best_knots_points["Country"] == country]  # best knots
+    data_eur_country = df_cases[df_cases['Country'] == country]
+    summary_eur_country = df_summaries[df_summaries["Country"] == country]
+
+    # Record important dates
+    date_pop_pct = summary_eur_country.Date_pop_pct
+    date_T = summary_eur_country.Date_T
+    date_first_restriction = summary_eur_country.Date_first_restriction
+    date_lockdown = summary_eur_country.Date_lockdown
+
+    # Calculate total number of simulation runs
+    n_runs = knots_best_country['N_unequal'].sum()
+
+    return 0

--- a/src/simulate_counterfactuals.py
+++ b/src/simulate_counterfactuals.py
@@ -1,4 +1,4 @@
-import pandas
+import pandas as pd
 
 
 def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots_points, df_summaries):
@@ -31,7 +31,7 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
     summary_eur_country = df_summaries[df_summaries["Country"] == country]
 
     # Record important dates
-    date_pop_pct = summary_eur_country.Date_pop_pct
+    date_pop_pct = pd.to_datetime(summary_eur_country.Date_pop_pct, format="%Y-%m-%d")
     date_T = summary_eur_country.Date_T
     date_first_restriction = summary_eur_country.Date_first_restriction
     date_lockdown = summary_eur_country.Date_lockdown
@@ -39,4 +39,11 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
     # Calculate total number of simulation runs
     n_runs = knots_best_country['N_unequal'].sum()
 
+    knots_best_country['Knot_date_1'] = pd.to_datetime(knots_best_country['Knot_date_1'], format="%Y-%m-%d")
+    knots_best_country['Knot_date_2'] = pd.to_datetime(knots_best_country['Knot_date_2'], format="%Y-%m-%d")
+
+    # Calculate maximum number of days earlier we can estimate FIRST RESTRICTION
+    # (minimum value of knot_date_1 greater than or equal to date_pop_pct)
+    max_days_counterfactual_first_restriction = min(knots_best_country.Knot_date_1 - date_pop_pct.repeat(knots_best_country.shape[0]).values)
+    max_days_counterfactual_lockdown = min(knots_best_country.Knot_date_2 - (date_pop_pct+pd.DateOffset(1)).repeat(knots_best_country.shape[0]).values)
     return 0

--- a/src/simulate_counterfactuals.py
+++ b/src/simulate_counterfactuals.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import numpy as np
+from src.process_data import get_important_dates, get_number_of_cases
 
-def simulate_country_counterfactuals(country, restrictions_shifts, df_cases, best_knots_points, df_summaries):
+
+def simulate_country_counterfactuals(country, counterfactual_shift, df_cases, best_knots_points, df_summaries):
     """
     Function that simulates the evolution of Covi19 cases for a country, given a shift in the time
     the restrictions where applied.
@@ -10,7 +12,7 @@ def simulate_country_counterfactuals(country, restrictions_shifts, df_cases, bes
     ----------
     country: str
         Country to be simulated
-    restrictions_shifts: tuple
+    counterfactual_shift: tuple
         Number of days earlier to implement FIRST RESTRICTION and LOCKDOWN
     df_cases: dataframe
         Historical case data.
@@ -27,66 +29,57 @@ def simulate_country_counterfactuals(country, restrictions_shifts, df_cases, bes
 
     # Filter datasets by country
     knots_best_country = best_knots_points[best_knots_points["Country"] == country]  # best knots
-    data_eur_country = df_cases[df_cases['Country'] == country]
-    summary_eur_country = df_summaries[df_summaries["Country"] == country]
 
     # Record important dates
+    dates = get_important_dates(country, df_summaries)
     # date for which cumulative cases first exceeded this percent (Date_pop_pct)
-    initial_date = pd.to_datetime(summary_eur_country.Date_pop_pct, format="%Y-%m-%d")
+    initial_date = dates['initial_date']
 
     # lastdate to include data
     # Date_max, Date_restrictions_eased + 28, or Date_lockdown_eased + 28, whichever comes first
-    maximum_date = pd.to_datetime(summary_eur_country.Date_T, format="%Y-%m-%d")
-    # date_first_restriction = summary_eur_country.Date_first_restriction
-    # date_lockdown = summary_eur_country.Date_lockdown
+    maximum_date = dates['maximum_date']
 
     # convert to dates to datetime
     knots_best_country['Knot_date_1'] = pd.to_datetime(knots_best_country['Knot_date_1'], format="%Y-%m-%d")
     knots_best_country['Knot_date_2'] = pd.to_datetime(knots_best_country['Knot_date_2'], format="%Y-%m-%d")
-    data_eur_country['Date'] = pd.to_datetime(data_eur_country['Date'])
 
     # Calculate maximum number of days earlier we can estimate FIRST RESTRICTION
-    # (minimum value of knot_date_1 greater than or equal to initial_date)
+    # (minimum value of knot_date_1 greater than or equal to date)
     max_days_counterfactual_first_restriction = min(
-        knots_best_country.Knot_date_1 - initial_date.repeat(knots_best_country.shape[0]).values).days
-    max_days_counterfactual_lockdown = min(knots_best_country.Knot_date_2 - (initial_date + pd.DateOffset(1)).repeat(
-        knots_best_country.shape[0]).values).days
+        knots_best_country.Knot_date_1 - pd.Series(initial_date).repeat(knots_best_country.shape[0]).values).days
+    max_days_counterfactual_lockdown = min(
+        knots_best_country.Knot_date_2 - pd.Series(initial_date + pd.DateOffset(1)).repeat(
+            knots_best_country.shape[0]).values).days
 
     # Determine all possible combinations of counterfactual days
     # (filter so that minimum value of knot_date_2 is always greater than knot_date_1)
-    x = pd.DataFrame(np.array([(x, y) for x in range(max_days_counterfactual_first_restriction + 1) for y in
+    possibles = pd.DataFrame(np.array([(x, y) for x in range(max_days_counterfactual_first_restriction + 1) for y in
                                range(max_days_counterfactual_lockdown + 1)]),
                      columns=['Poss_days_counterfactual_first_restriction', 'Poss_days_counterfactual_lockdown'])
-    possible_days_counterfactual = x[
-        (x['Poss_days_counterfactual_lockdown'] - x['Poss_days_counterfactual_first_restriction']) <= (
-                    max_days_counterfactual_lockdown - max_days_counterfactual_first_restriction - 1)]
+    possible_days_counterfactual = possibles[
+        (possibles['Poss_days_counterfactual_lockdown'] - possibles['Poss_days_counterfactual_first_restriction']) <= (
+                max_days_counterfactual_lockdown - max_days_counterfactual_first_restriction - 1)]
 
     match = possible_days_counterfactual[
-        (possible_days_counterfactual['Poss_days_counterfactual_first_restriction'] == restrictions_shifts[0]) \
-        & (possible_days_counterfactual['Poss_days_counterfactual_lockdown'] == restrictions_shifts[1])]
+        (possible_days_counterfactual['Poss_days_counterfactual_first_restriction'] == counterfactual_shift[0]) \
+        & (possible_days_counterfactual['Poss_days_counterfactual_lockdown'] == counterfactual_shift[1])]
 
     if (match.shape[0] == 0):
         raise RuntimeError("Stop - cannot estimate counterfactual")
 
     # get initial number of cases for the first day of the simulation
-    initial_case_number = data_eur_country[data_eur_country['Date'] == (initial_date.values[0] - pd.Timedelta(days=1))][
-        'Daily_cases_MA7'].values
-
-    # get initial cumulative number of cases for the first day of the simulation
-    initial_cumulative_case_number = \
-    data_eur_country[data_eur_country['Date'] == (initial_date.values[0] - pd.Timedelta(days=1))][
-        'Cumulative_cases_end_MA7'].values
+    initial_case_number, initial_cumulative_case_number = get_number_of_cases(country, df_cases, initial_date)
 
     # run simulation
-    daily_cases_sim = simulate_counterfactuals(knots_best_country, initial_date, maximum_date, initial_case_number,  \
-                                               restrictions_shifts)
+    daily_cases_sim = simulate_counterfactuals(knots_best_country, initial_date, maximum_date, initial_case_number, \
+                                               counterfactual_shift)
 
     # get mean value of time series.
     daily_cases_sim_mean = daily_cases_sim.mean(axis=0)
 
     daily_cases_sim_cum = daily_cases_sim.copy()
     daily_cases_sim_cum.loc[:,
-    (initial_date.values[0] - pd.Timedelta(days=1)).strftime("%m-%d-%Y")] = initial_cumulative_case_number.repeat( \
+    (initial_date - pd.Timedelta(days=1)).strftime("%m-%d-%Y")] = initial_cumulative_case_number.repeat( \
         daily_cases_sim_cum.shape[0])
     daily_cases_sim_cum = daily_cases_sim_cum.reindex(sorted(daily_cases_sim_cum.columns), axis=1)
 
@@ -97,7 +90,7 @@ def simulate_country_counterfactuals(country, restrictions_shifts, df_cases, bes
     return daily_cases_sim_mean, daily_cases_sim_cum_sum_mean
 
 
-def simulate_counterfactuals(knots_best, initial_date, maximum_date, initial_case_number, restrictions_shifts):
+def simulate_counterfactuals(knots_best, initial_date, maximum_date, initial_case_number, counterfactual_shift):
     """
 
     Function that runs the simulation of the epidemic history given an initial case number, growth parameters and
@@ -114,7 +107,7 @@ def simulate_counterfactuals(knots_best, initial_date, maximum_date, initial_cas
         Maximum date to run the simulation
     initial_case_number:
         Initial case numbers observed at the initial date
-    restrictions_shifts: tuple
+    counterfactual_shift: tuple
         Number of days earlier to implement FIRST RESTRICTION and LOCKDOWN
 
     Returns
@@ -124,14 +117,14 @@ def simulate_counterfactuals(knots_best, initial_date, maximum_date, initial_cas
 
     """
 
-    n_days_counterfactual_first_restriction = restrictions_shifts[0]
-    n_days_counterfactual_lockdown = restrictions_shifts[1]
+    n_days_counterfactual_first_restriction = counterfactual_shift[0]
+    n_days_counterfactual_lockdown = counterfactual_shift[1]
 
     knots_best['Knot_date_1'] = knots_best['Knot_date_1'] - pd.Timedelta(days=n_days_counterfactual_first_restriction)
     knots_best['Knot_date_2'] = knots_best['Knot_date_2'] - pd.Timedelta(days=n_days_counterfactual_lockdown)
 
     # Set dates to simulate
-    dates = pd.date_range(start=initial_date.values[0], end=maximum_date.values[0], freq='D').tolist()
+    dates = pd.date_range(start=initial_date, end=maximum_date, freq='D').tolist()
 
     daily_cases_sim = pd.DataFrame()
 
@@ -154,11 +147,11 @@ def simulate_counterfactuals(knots_best, initial_date, maximum_date, initial_cas
         n_runs_i = knots_best_country_counterfactual_i['N_unequal']
 
         daily_cases_sim_i = pd.DataFrame(index=[i for i in range(n_runs_i)],
-                                         columns=pd.date_range(start=initial_date.values[0] - pd.Timedelta(days=1),
-                                                               end=maximum_date.values[0],
+                                         columns=pd.date_range(start=initial_date - pd.Timedelta(days=1),
+                                                               end=maximum_date,
                                                                freq='D').strftime("%m-%d-%Y").tolist())
 
-        daily_cases_sim_i.iloc[:, 0] = initial_case_number.repeat(n_runs_i)
+        daily_cases_sim_i.iloc[:, 0] = [initial_case_number for _ in range(n_runs_i)]
 
         for date in dates:
             inc_tminus1 = daily_cases_sim_i[(date - pd.Timedelta(days=1)).strftime("%m-%d-%Y")]
@@ -189,5 +182,3 @@ def simulate_counterfactuals(knots_best, initial_date, maximum_date, initial_cas
         daily_cases_sim = pd.concat([daily_cases_sim, daily_cases_sim_i])
 
     return daily_cases_sim
-
-

--- a/src/simulate_counterfactuals.py
+++ b/src/simulate_counterfactuals.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots_points, df_summaries):
+def simulate_country_counterfactuals(country, restrictions_shifts, df_cases, best_knots_points, df_summaries):
     """
     Function that simulates the evolution of Covi19 cases for a country, given a shift in the time
     the restrictions where applied.
@@ -21,7 +21,7 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
 
     Returns
     -------
-    A time series with the simulated daily cases.
+    Two time series with the simulated daily and cumulative cases.
 
     """
 
@@ -31,60 +31,115 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
     summary_eur_country = df_summaries[df_summaries["Country"] == country]
 
     # Record important dates
-    date_pop_pct = pd.to_datetime(summary_eur_country.Date_pop_pct, format="%Y-%m-%d")
-    date_T = pd.to_datetime(summary_eur_country.Date_T, format="%Y-%m-%d")
-    date_first_restriction = summary_eur_country.Date_first_restriction
-    date_lockdown = summary_eur_country.Date_lockdown
+    # date for which cumulative cases first exceeded this percent (Date_pop_pct)
+    initial_date = pd.to_datetime(summary_eur_country.Date_pop_pct, format="%Y-%m-%d")
 
-    # Calculate total number of simulation runs
-    n_runs = knots_best_country['N_unequal'].sum()
+    # lastdate to include data
+    # Date_max, Date_restrictions_eased + 28, or Date_lockdown_eased + 28, whichever comes first
+    maximum_date = pd.to_datetime(summary_eur_country.Date_T, format="%Y-%m-%d")
+    # date_first_restriction = summary_eur_country.Date_first_restriction
+    # date_lockdown = summary_eur_country.Date_lockdown
 
+    # convert to dates to datetime
     knots_best_country['Knot_date_1'] = pd.to_datetime(knots_best_country['Knot_date_1'], format="%Y-%m-%d")
     knots_best_country['Knot_date_2'] = pd.to_datetime(knots_best_country['Knot_date_2'], format="%Y-%m-%d")
     data_eur_country['Date'] = pd.to_datetime(data_eur_country['Date'])
+
     # Calculate maximum number of days earlier we can estimate FIRST RESTRICTION
-    # (minimum value of knot_date_1 greater than or equal to date_pop_pct)
-    max_days_counterfactual_first_restriction = min(knots_best_country.Knot_date_1 - date_pop_pct.repeat(knots_best_country.shape[0]).values).days
-    max_days_counterfactual_lockdown = min(knots_best_country.Knot_date_2 - (date_pop_pct+pd.DateOffset(1)).repeat(knots_best_country.shape[0]).values).days
+    # (minimum value of knot_date_1 greater than or equal to initial_date)
+    max_days_counterfactual_first_restriction = min(
+        knots_best_country.Knot_date_1 - initial_date.repeat(knots_best_country.shape[0]).values).days
+    max_days_counterfactual_lockdown = min(knots_best_country.Knot_date_2 - (initial_date + pd.DateOffset(1)).repeat(
+        knots_best_country.shape[0]).values).days
 
     # Determine all possible combinations of counterfactual days
     # (filter so that minimum value of knot_date_2 is always greater than knot_date_1)
-    x =  pd.DataFrame(np.array([(x, y) for x in range(max_days_counterfactual_first_restriction+1) for y in range(max_days_counterfactual_lockdown+1)]),columns=['Poss_days_counterfactual_first_restriction', 'Poss_days_counterfactual_lockdown'])
-    possible_days_counterfactual = x[(x['Poss_days_counterfactual_lockdown']-x['Poss_days_counterfactual_first_restriction'])<=(max_days_counterfactual_lockdown - max_days_counterfactual_first_restriction - 1) ]
+    x = pd.DataFrame(np.array([(x, y) for x in range(max_days_counterfactual_first_restriction + 1) for y in
+                               range(max_days_counterfactual_lockdown + 1)]),
+                     columns=['Poss_days_counterfactual_first_restriction', 'Poss_days_counterfactual_lockdown'])
+    possible_days_counterfactual = x[
+        (x['Poss_days_counterfactual_lockdown'] - x['Poss_days_counterfactual_first_restriction']) <= (
+                    max_days_counterfactual_lockdown - max_days_counterfactual_first_restriction - 1)]
 
-    # Set dates to simulate
-    dates = pd.date_range(start=date_pop_pct.values[0], end=date_T.values[0],freq='D').tolist()
-
-    # Define number of best knot point pairs
-    n_knots_best = knots_best_country.shape[0]
-
-    n_days_counterfactual_first_restriction = restrictions_shifts[0]
-    n_days_counterfactual_lockdown =restrictions_shifts[1]
-
-    match = possible_days_counterfactual[(possible_days_counterfactual['Poss_days_counterfactual_first_restriction']==restrictions_shifts[0]) \
-                                 & (possible_days_counterfactual['Poss_days_counterfactual_lockdown']==restrictions_shifts[1])]
+    match = possible_days_counterfactual[
+        (possible_days_counterfactual['Poss_days_counterfactual_first_restriction'] == restrictions_shifts[0]) \
+        & (possible_days_counterfactual['Poss_days_counterfactual_lockdown'] == restrictions_shifts[1])]
 
     if (match.shape[0] == 0):
-        print("Stop - cannot estimate counterfactual")
+        raise RuntimeError("Stop - cannot estimate counterfactual")
 
-    knots_best_country_counterfactual = knots_best_country.copy()
+    # get initial number of cases for the first day of the simulation
+    initial_case_number = data_eur_country[data_eur_country['Date'] == (initial_date.values[0] - pd.Timedelta(days=1))][
+        'Daily_cases_MA7'].values
 
-    knots_best_country_counterfactual['Knot_date_1'] = knots_best_country_counterfactual['Knot_date_1'] - pd.Timedelta(days=n_days_counterfactual_first_restriction)
-    knots_best_country_counterfactual['Knot_date_2'] = knots_best_country_counterfactual['Knot_date_2'] - pd.Timedelta(days=n_days_counterfactual_lockdown)
+    # get initial cumulative number of cases for the first day of the simulation
+    initial_cumulative_case_number = \
+    data_eur_country[data_eur_country['Date'] == (initial_date.values[0] - pd.Timedelta(days=1))][
+        'Cumulative_cases_end_MA7'].values
+
+    # run simulation
+    daily_cases_sim = simulate_counterfactuals(knots_best_country, initial_date, maximum_date, initial_case_number,  \
+                                               restrictions_shifts)
+
+    # get mean value of time series.
+    daily_cases_sim_mean = daily_cases_sim.mean(axis=0)
+
+    daily_cases_sim_cum = daily_cases_sim.copy()
+    daily_cases_sim_cum.loc[:,
+    (initial_date.values[0] - pd.Timedelta(days=1)).strftime("%m-%d-%Y")] = initial_cumulative_case_number.repeat( \
+        daily_cases_sim_cum.shape[0])
+    daily_cases_sim_cum = daily_cases_sim_cum.reindex(sorted(daily_cases_sim_cum.columns), axis=1)
+
+    # get cummulative values of time series.
+    daily_cases_sim_cum_sum = daily_cases_sim_cum.cumsum(axis=1)
+    daily_cases_sim_cum_sum_mean = daily_cases_sim_cum_sum.mean(axis=0)
+
+    return daily_cases_sim_mean, daily_cases_sim_cum_sum_mean
 
 
-    daily_cases_sim =  pd.DataFrame()#columns=pd.date_range(start=date_pop_pct.values[0]-pd.Timedelta(days=1), end=date_T.values[0],freq='D').date.tolist())
+def simulate_counterfactuals(knots_best, initial_date, maximum_date, initial_case_number, restrictions_shifts):
+    """
 
-    start = pd.datetime.now()
+    Function that runs the simulation of the epidemic history given an initial case number, growth parameters and
+    growth inflection dates.
 
-    for i in range(n_knots_best):
-        knots_best_country_counterfactual_i = knots_best_country_counterfactual.iloc[i]
+
+    Parameters
+    ----------
+    knots_best: dataframe
+        Dataframe that contains the best knot dates estimated and different growth factors for a country
+    initial_date: datetime
+        Initial date to start the simulation
+    maximum_date: datetime
+        Maximum date to run the simulation
+    initial_case_number:
+        Initial case numbers observed at the initial date
+    restrictions_shifts: tuple
+        Number of days earlier to implement FIRST RESTRICTION and LOCKDOWN
+
+    Returns
+    -------
+
+        A dataframe with simulated case numbers for date period.
+
+    """
+
+    n_days_counterfactual_first_restriction = restrictions_shifts[0]
+    n_days_counterfactual_lockdown = restrictions_shifts[1]
+
+    knots_best['Knot_date_1'] = knots_best['Knot_date_1'] - pd.Timedelta(days=n_days_counterfactual_first_restriction)
+    knots_best['Knot_date_2'] = knots_best['Knot_date_2'] - pd.Timedelta(days=n_days_counterfactual_lockdown)
+
+    # Set dates to simulate
+    dates = pd.date_range(start=initial_date.values[0], end=maximum_date.values[0], freq='D').tolist()
+
+    daily_cases_sim = pd.DataFrame()
+
+    for i in range(knots_best.shape[0]):
+        knots_best_country_counterfactual_i = knots_best.iloc[i]
 
         # Record number of knots
         n_knots = knots_best_country_counterfactual_i['N_knots']
-
-        # Define number of simulation runs for specified knot dates
-        n_runs_i= knots_best_country_counterfactual_i['N_unequal']
 
         # Set knot dates
         knot_date_1_i = knots_best_country_counterfactual_i['Knot_date_1']
@@ -99,22 +154,21 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
         n_runs_i = knots_best_country_counterfactual_i['N_unequal']
 
         daily_cases_sim_i = pd.DataFrame(index=[i for i in range(n_runs_i)],
-            columns=pd.date_range(start=date_pop_pct.values[0] - pd.Timedelta(days=1), end=date_T.values[0],
-                                  freq='D').strftime("%m-%d-%Y").tolist())
+                                         columns=pd.date_range(start=initial_date.values[0] - pd.Timedelta(days=1),
+                                                               end=maximum_date.values[0],
+                                                               freq='D').strftime("%m-%d-%Y").tolist())
 
-        daily_cases_sim_i.iloc[:, 0] = \
-        data_eur_country[data_eur_country['Date'] == (date_pop_pct.values[0] - pd.Timedelta(days=1))][
-            'Daily_cases_MA7'].values.repeat(n_runs_i)
+        daily_cases_sim_i.iloc[:, 0] = initial_case_number.repeat(n_runs_i)
 
         for date in dates:
             inc_tminus1 = daily_cases_sim_i[(date - pd.Timedelta(days=1)).strftime("%m-%d-%Y")]
 
             # Define growth parameters
-            if (n_knots == 0) :  # NO knot points
+            if (n_knots == 0):  # NO knot points
                 growth = growth_factor_1_i
 
-            elif (n_knots == 1) :  # ONE knot point
-                if date <= knot_date_1_i :
+            elif (n_knots == 1):  # ONE knot point
+                if date <= knot_date_1_i:
                     growth = growth_factor_1_i
                 else:
                     growth = growth_factor_2_i
@@ -128,24 +182,12 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
 
             # Calculate daily cases at time t and record
             inc_t = growth * inc_tminus1
-            daily_cases_sim_i.loc[:,date.strftime("%m-%d-%Y")] = inc_t
+            daily_cases_sim_i.loc[:, date.strftime("%m-%d-%Y")] = inc_t
 
             # Bind knot-specific dataframes to full scenario dataframe
 
         daily_cases_sim = pd.concat([daily_cases_sim, daily_cases_sim_i])
 
-    daily_cases_sim_mean = daily_cases_sim.mean(axis=0)
-
-    cum_init = data_eur_country[data_eur_country['Date'] == (date_pop_pct.values[0] - pd.Timedelta(days=1))][
-        'Cumulative_cases_end_MA7'].values
-
-    daily_cases_sim_cum = daily_cases_sim.copy()
-    daily_cases_sim_cum.loc[:, (date_pop_pct.values[0] - pd.Timedelta(days=1)).strftime("%m-%d-%Y")] = cum_init.repeat(\
-        daily_cases_sim_cum.shape[0])
-    daily_cases_sim_cum = daily_cases_sim_cum.reindex(sorted(daily_cases_sim_cum.columns), axis=1)
-    daily_cases_sim_cum_sum = daily_cases_sim_cum.cumsum(axis=1)
-
-    daily_cases_sim_cum_sum_mean = daily_cases_sim_cum_sum.mean(axis=0)
+    return daily_cases_sim
 
 
-    return daily_cases_sim_mean

--- a/src/simulate_counterfactuals.py
+++ b/src/simulate_counterfactuals.py
@@ -1,5 +1,5 @@
 import pandas as pd
-
+import numpy as np
 
 def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots_points, df_summaries):
     """
@@ -10,7 +10,7 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
     ----------
     country: str
         Country to be simulated
-    restrictions_shifts: int
+    restrictions_shifts: tuple
         Number of days earlier to implement FIRST RESTRICTION and LOCKDOWN
     df_cases: dataframe
         Historical case data.
@@ -32,7 +32,7 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
 
     # Record important dates
     date_pop_pct = pd.to_datetime(summary_eur_country.Date_pop_pct, format="%Y-%m-%d")
-    date_T = summary_eur_country.Date_T
+    date_T = pd.to_datetime(summary_eur_country.Date_T, format="%Y-%m-%d")
     date_first_restriction = summary_eur_country.Date_first_restriction
     date_lockdown = summary_eur_country.Date_lockdown
 
@@ -44,6 +44,37 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
 
     # Calculate maximum number of days earlier we can estimate FIRST RESTRICTION
     # (minimum value of knot_date_1 greater than or equal to date_pop_pct)
-    max_days_counterfactual_first_restriction = min(knots_best_country.Knot_date_1 - date_pop_pct.repeat(knots_best_country.shape[0]).values)
-    max_days_counterfactual_lockdown = min(knots_best_country.Knot_date_2 - (date_pop_pct+pd.DateOffset(1)).repeat(knots_best_country.shape[0]).values)
-    return 0
+    max_days_counterfactual_first_restriction = min(knots_best_country.Knot_date_1 - date_pop_pct.repeat(knots_best_country.shape[0]).values).days
+    max_days_counterfactual_lockdown = min(knots_best_country.Knot_date_2 - (date_pop_pct+pd.DateOffset(1)).repeat(knots_best_country.shape[0]).values).days
+
+    # Determine all possible combinations of counterfactual days
+    # (filter so that minimum value of knot_date_2 is always greater than knot_date_1)
+    x =  pd.DataFrame(np.array([(x, y) for x in range(max_days_counterfactual_first_restriction+1) for y in range(max_days_counterfactual_lockdown+1)]),columns=['Poss_days_counterfactual_first_restriction', 'Poss_days_counterfactual_lockdown'])
+    possible_days_counterfactual = x[(x['Poss_days_counterfactual_lockdown']-x['Poss_days_counterfactual_first_restriction'])<=(max_days_counterfactual_lockdown - max_days_counterfactual_first_restriction - 1) ]
+
+    # Set dates to simulate
+    dates = pd.date_range(start=date_pop_pct.values[0], end=date_T.values[0],freq='D').tolist()
+
+    # Define number of best knot point pairs
+    n_knots_best = knots_best_country.shape[0]
+
+    n_days_counterfactual_first_restriction = restrictions_shifts[0]
+    n_days_counterfactual_lockdown =restrictions_shifts[1]
+
+    match = possible_days_counterfactual[(possible_days_counterfactual['Poss_days_counterfactual_first_restriction']==restrictions_shifts[0]) \
+                                 & (possible_days_counterfactual['Poss_days_counterfactual_lockdown']==restrictions_shifts[1])]
+
+    if (match.shape[0] == 0):
+        print("Stop - cannot estimate counterfactual")
+
+    knots_best_country_counterfactual = knots_best_country.copy()
+
+    knots_best_country_counterfactual['Knot_date_1'] = knots_best_country_counterfactual['Knot_date_1'] - pd.Timedelta(days=n_days_counterfactual_first_restriction)
+    knots_best_country_counterfactual['Knot_date_2'] = knots_best_country_counterfactual['Knot_date_2'] - pd.Timedelta(days=n_days_counterfactual_lockdown)
+
+
+    daily_cases_sim =  pd.DataFrame(columns=pd.date_range(start=date_pop_pct.values[0]-pd.Timedelta(days=1), end=date_T.values[0],freq='D').date.tolist())
+
+    start = pd.datetime.now()
+
+    return x

--- a/src/simulate_counterfactuals.py
+++ b/src/simulate_counterfactuals.py
@@ -41,7 +41,7 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
 
     knots_best_country['Knot_date_1'] = pd.to_datetime(knots_best_country['Knot_date_1'], format="%Y-%m-%d")
     knots_best_country['Knot_date_2'] = pd.to_datetime(knots_best_country['Knot_date_2'], format="%Y-%m-%d")
-
+    data_eur_country['Date'] = pd.to_datetime(data_eur_country['Date'])
     # Calculate maximum number of days earlier we can estimate FIRST RESTRICTION
     # (minimum value of knot_date_1 greater than or equal to date_pop_pct)
     max_days_counterfactual_first_restriction = min(knots_best_country.Knot_date_1 - date_pop_pct.repeat(knots_best_country.shape[0]).values).days
@@ -77,4 +77,32 @@ def simulate_counterfactuals(country, restrictions_shifts, df_cases , best_knots
 
     start = pd.datetime.now()
 
+    for i in range(n_knots_best):
+        knots_best_country_counterfactual_i = knots_best_country_counterfactual.iloc[i]
+
+        # Record number of knots
+        n_knots = knots_best_country_counterfactual_i['N_knots']
+
+        # Define number of simulation runs for specified knot dates
+        n_runs_i= knots_best_country_counterfactual_i['N_unequal']
+
+        # Set knot dates
+        knot_date_1_i = knots_best_country_counterfactual_i['Knot_date_1']
+        knot_date_2_i = knots_best_country_counterfactual_i['Knot_date_2']
+
+        # Define mean growth parameters
+        growth_factor_1_i = knots_best_country_counterfactual_i['Growth_factor_1']
+        growth_factor_2_i = knots_best_country_counterfactual_i['Growth_factor_2']
+        growth_factor_3_i = knots_best_country_counterfactual_i['Growth_factor_3']
+
+        # Define number of simulation runs for specified knot dates
+        n_runs_i = knots_best_country_counterfactual_i['N_unequal']
+
+        daily_cases_sim_i = pd.DataFrame(index=[i for i in range(n_runs_i)],
+            columns=pd.date_range(start=date_pop_pct.values[0] - pd.Timedelta(days=1), end=date_T.values[0],
+                                  freq='D').date.tolist())
+
+        daily_cases_sim_i.iloc[:, 0] = \
+        data_eur_country[data_eur_country['Date'] == (date_pop_pct.values[0] - pd.Timedelta(days=1))][
+            'Daily_cases_MA7'].values.repeat(n_runs_i)
     return x

--- a/tests/test_process_data.py
+++ b/tests/test_process_data.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 import os
 import pandas as pd
-from src.process_data import get_natural_history_data
+from src.process_data import get_natural_history_data,get_important_dates, get_number_of_cases
 
 
 
@@ -20,5 +20,32 @@ def test_get_natural_history_data():
 
     assert (ts_data_country_daily.shape[0] != 0)
     assert (ts_data_country_cum.shape[0] != 0)
+
+def test_get_important_dates():
+
+    url_summaries = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Results/Country%20summaries.csv'
+    df_summaries = pd.read_csv(url_summaries)
+
+    country = 'United Kingdom'
+
+    dates = get_important_dates(country, df_summaries)
+
+    assert (len(dates.keys()) != 0)
+
+def test_get_initial_number_of_cases():
+    url_cases = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Data/Formatted/Cases_deaths_data_europe.csv'
+    df_cases = pd.read_csv(url_cases)
+
+    country = 'United Kingdom'
+    date =  pd.to_datetime('2020-05-21', format="%Y-%m-%d")
+
+    cases, cum_cases = get_number_of_cases(country, df_cases, date)
+
+    assert (cases == 2318.0)
+    assert (cum_cases == 237741.431)
+
+
+
+
 
 

--- a/tests/test_process_data.py
+++ b/tests/test_process_data.py
@@ -1,0 +1,24 @@
+"""
+Test the functions in process_data.py
+"""
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import os
+import pandas as pd
+from src.process_data import get_natural_history_data
+
+
+
+def test_get_natural_history_data():
+    url_cases = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Data/Formatted/Cases_deaths_data_europe.csv'
+    df_cases = pd.read_csv(url_cases)
+
+
+
+    ts_data_country_daily, ts_data_country_cum = get_natural_history_data('United Kingdom',df_cases)
+
+    assert (ts_data_country_daily.shape[0] != 0)
+    assert (ts_data_country_cum.shape[0] != 0)
+
+

--- a/tests/test_simulate_counterfactuals.py
+++ b/tests/test_simulate_counterfactuals.py
@@ -22,12 +22,17 @@ def test_simulate_counterfactuals():
     country = 'United Kingdom'
 
     ts_daily_cases, ts_cum_daily_cases = simulate_country_counterfactuals(country, (7, 7), df_cases, df_best_knot, \
-                                                                  df_summaries)
+                                                                          df_summaries)
 
-    data_eur_country_daily = df_cases[df_cases['Country'] == country].reindex('Date')['Daily_cases_MA7']
-    data_eur_country_cum = df_cases[df_cases['Country'] == country].reindex('Date')['Cumulative_cases_end_MA7']
+    assert (ts_daily_cases.shape[0] == 102)
+    assert (ts_cum_daily_cases.shape[0] == 102)
 
+    assert (ts_daily_cases[-1] == 290.08613025000807)
 
-    assert (ts_daily_cases.shape[0] != 0)
-    assert (ts_cum_daily_cases.shape[0] != 0)
+    assert (ts_daily_cases[10] == 243.96895010215306)
+    assert (ts_daily_cases[50] == 830.314137571764)
+    assert (ts_cum_daily_cases[40] == 24954.909695002152)
 
+    assert (ts_cum_daily_cases.index[10] == '03-11-2020')
+    assert (ts_cum_daily_cases.index[-1] == '06-10-2020')
+    assert (ts_cum_daily_cases.index[0] == '03-01-2020')

--- a/tests/test_simulate_counterfactuals.py
+++ b/tests/test_simulate_counterfactuals.py
@@ -1,4 +1,3 @@
-
 """
 Test the functions in simulate_counterfactuals.py
 """
@@ -7,10 +6,10 @@ import pandas as pd
 import pytest
 import os
 import pandas as pd
-from src.simulate_counterfactuals import simulate_counterfactuals
+from src.simulate_counterfactuals import simulate_country_counterfactuals
+
 
 def test_simulate_counterfactuals():
-
     url_cases = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Data/Formatted/Cases_deaths_data_europe.csv'
     df_cases = pd.read_csv(url_cases)
 
@@ -20,6 +19,15 @@ def test_simulate_counterfactuals():
     url_summaries = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Results/Country%20summaries.csv'
     df_summaries = pd.read_csv(url_summaries)
 
+    country = 'United Kingdom'
+
+    ts_daily_cases, ts_cum_daily_cases = simulate_country_counterfactuals(country, (7, 7), df_cases, df_best_knot, \
+                                                                  df_summaries)
+
+    data_eur_country_daily = df_cases[df_cases['Country'] == country].reindex('Date')['Daily_cases_MA7']
+    data_eur_country_cum = df_cases[df_cases['Country'] == country].reindex('Date')['Cumulative_cases_end_MA7']
 
 
-    ts_daily_cases =  simulate_counterfactuals('United Kingdom',(7,7),df_cases,df_best_knot,df_summaries)
+    assert (ts_daily_cases.shape[0] != 0)
+    assert (ts_cum_daily_cases.shape[0] != 0)
+

--- a/tests/test_simulate_counterfactuals.py
+++ b/tests/test_simulate_counterfactuals.py
@@ -22,4 +22,4 @@ def test_simulate_counterfactuals():
 
 
 
-    ts_daily_cases =  simulate_counterfactuals('United Kingdom',7,df_cases,df_best_knot,df_summaries)
+    ts_daily_cases =  simulate_counterfactuals('United Kingdom',(7,7),df_cases,df_best_knot,df_summaries)

--- a/tests/test_simulate_counterfactuals.py
+++ b/tests/test_simulate_counterfactuals.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
 import os
+import pandas as pd
 from src.simulate_counterfactuals import simulate_counterfactuals
 
 def test_simulate_counterfactuals():
@@ -14,11 +15,11 @@ def test_simulate_counterfactuals():
     df_cases = pd.read_csv(url_cases)
 
     url_best_knot = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Results/Best%20knot%20points.csv'
-    df_best_knot = pd.read_csv(url_best_knot, index_col=0, parse_dates=[0])
+    df_best_knot = pd.read_csv(url_best_knot)
 
     url_summaries = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Results/Country%20summaries.csv'
-    df_summaries = pd.read_csv(url_summaries, index_col=0, parse_dates=[0])
+    df_summaries = pd.read_csv(url_summaries)
 
 
 
-    ts_daily_cases =  simulate_counterfactuals('UK',7,df_cases,df_best_knot,df_summaries)
+    ts_daily_cases =  simulate_counterfactuals('United Kingdom',7,df_cases,df_best_knot,df_summaries)

--- a/tests/test_simulate_counterfactuals.py
+++ b/tests/test_simulate_counterfactuals.py
@@ -1,0 +1,24 @@
+
+"""
+Test the functions in simulate_counterfactuals.py
+"""
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import os
+from src.simulate_counterfactuals import simulate_counterfactuals
+
+def test_simulate_counterfactuals():
+
+    url_cases = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Data/Formatted/Cases_deaths_data_europe.csv'
+    df_cases = pd.read_csv(url_cases)
+
+    url_best_knot = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Results/Best%20knot%20points.csv'
+    df_best_knot = pd.read_csv(url_best_knot, index_col=0, parse_dates=[0])
+
+    url_summaries = 'https://raw.githubusercontent.com/alan-turing-institute/CounterfactualCovid19-inputs/develop/Results/Country%20summaries.csv'
+    df_summaries = pd.read_csv(url_summaries, index_col=0, parse_dates=[0])
+
+
+
+    ts_daily_cases =  simulate_counterfactuals('UK',7,df_cases,df_best_knot,df_summaries)


### PR DESCRIPTION
Fixes #10

[**Counterfactual simulation functions**](https://github.com/alan-turing-institute/CounterfactualCovid19/pull/12/files#diff-fd085302695b2da267743e06ba25b7218ea6c9fcb4c0d8f4148e64f6d6dd8c0a):
- [x] Function to run simulation for a given country (get all relevant information for that country and then runs the next function)
- [x] Function to run simulation based on knot dates, date ranges and initial number of cases.

[**Data processing functions**](https://github.com/alan-turing-institute/CounterfactualCovid19/pull/12/files#diff-80c0caf66bd3a584dec4b7b316930454dad9b5710e314f5bbb27c9ad41f5263e):
- [x] Function to get important dates for a country
- [x] Functions to get total number of cases for a country on a given date
- [x] Function to get the natural history data for a given country 

**Other implementations**:
- [x] Passing tests to all above functions.
- [x] Updated README with instructions of how to run
- [x] requirement.txt files for creating an environment.
