### PR TITLE
Get cases data from backend

### DIFF
--- a/backend/cases/migrations/0001_casesrecord.py
+++ b/backend/cases/migrations/0001_casesrecord.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("date", models.DateField()),
-                ("cases", models.FloatField()),
+                ("weekly_avg_cases", models.FloatField()),
                 (
                     "country",
                     models.ForeignKey(

--- a/backend/cases/models/concrete.py
+++ b/backend/cases/models/concrete.py
@@ -12,7 +12,7 @@ class CasesRecord(models.Model):
         Country, related_name="cases_records", on_delete=models.CASCADE
     )
     date = models.DateField()
-    cases = models.FloatField()
+    weekly_avg_cases = models.FloatField()
 
     def __str__(self):
-        return f"{self.country.name} had {self.cases} on {self.date}"
+        return f"{self.country.name} had {self.weekly_avg_cases} on {self.date}"

--- a/backend/cases/models/ephemeral.py
+++ b/backend/cases/models/ephemeral.py
@@ -1,14 +1,15 @@
-from .concrete import CasesRecord
-import pandas as pd
 from datetime import date
+import pandas as pd
+import numpy as np
+from .concrete import CasesRecord
 
 
 class CounterfactualCasesRecord:
-    def __init__(self, iso_code, date, cases, cumulative_cases):
+    def __init__(self, iso_code, date, weekly_avg_cases, summed_avg_cases):
         self.iso_code = iso_code
         self.date = date
-        self.cases = cases
-        self.cumulative_cases = cumulative_cases
+        self.weekly_avg_cases = weekly_avg_cases
+        self.summed_avg_cases = summed_avg_cases
 
     @staticmethod
     def simulate_counterfactual_dataframes(iso_codes, start_date, end_date):
@@ -19,7 +20,7 @@ class CounterfactualCasesRecord:
                 "country__iso_code",
                 "country__population",
                 "date",
-                "cases",
+                "weekly_avg_cases",
             )
         ).rename(
             columns={
@@ -37,7 +38,7 @@ class CounterfactualCasesRecord:
             iso_codes = df_data.iso_code.unique()
         # Simulate each requested country
         df_counterfactuals = [
-            CounterfactualCasesRecord.add_cumulative(
+            CounterfactualCasesRecord.add_summed(
                 CounterfactualCasesRecord.simulate_single_country(
                     df_data[df_data["iso_code"] == iso_code]
                 )
@@ -71,18 +72,19 @@ class CounterfactualCasesRecord:
         return sum([df.to_dict("records") for df in df_latest_dates], [])
 
     @staticmethod
-    def add_cumulative(df_country_data):
+    def add_summed(df_country_data):
         """Counterfactual simulation for a single country"""
         df_out = df_country_data.sort_values(by=["date"])
-        df_out["cumulative_cases"] = df_out["cases"].cumsum()
+        df_out["summed_avg_cases"] = df_out["weekly_avg_cases"].cumsum()
         return df_out
 
     @staticmethod
     def simulate_single_country(df_country_data):
         """Counterfactual simulation for a single country"""
+        df_country_data["weekly_avg_cases"] += np.random.uniform(0, 5, df_country_data.shape[0])
         return df_country_data
 
     def __str__(self):
         return (
-            f"({self.iso_code}) [{self.date}] => {self.cases} ({self.cumulative_cases})"
+            f"({self.iso_code}) [{self.date}] => {self.weekly_avg_cases} ({self.summed_avg_cases})"
         )

--- a/backend/cases/serializers/concrete.py
+++ b/backend/cases/serializers/concrete.py
@@ -6,31 +6,31 @@ from django.db.models import Sum, F, Window, When, Max
 
 class CasesRealDailyAbsoluteSerializer(serializers.ModelSerializer):
     iso_code = serializers.PrimaryKeyRelatedField(source="country", read_only=True)
-    cumulative_cases = serializers.FloatField()
+    summed_avg_cases = serializers.FloatField()
 
     class Meta:
         model = CasesRecord
         fields = (
             "iso_code",
             "date",
-            "cases",
-            "cumulative_cases",
+            "weekly_avg_cases",
+            "summed_avg_cases",
         )
 
 
 class CasesRealDailyNormalisedSerializer(serializers.ModelSerializer):
     iso_code = serializers.PrimaryKeyRelatedField(source="country", read_only=True)
-    cases_per_million = serializers.SerializerMethodField()
-    cumulative_cases_per_million = serializers.SerializerMethodField()
+    weekly_avg_cases_per_million = serializers.SerializerMethodField()
+    summed_avg_cases_per_million = serializers.SerializerMethodField()
 
-    def get_cases_per_million(self, record):
+    def get_weekly_avg_cases_per_million(self, record):
         if record.country.population and record.country.population != 0:
-            return 1e6 * record.cases / record.country.population
+            return 1e6 * record.weekly_avg_cases / record.country.population
         return 0
 
-    def get_cumulative_cases_per_million(self, record):
+    def get_summed_avg_cases_per_million(self, record):
         if record.country.population and record.country.population != 0:
-            return 1e6 * record.cumulative_cases / record.country.population
+            return 1e6 * record.summed_avg_cases / record.country.population
         return 0
 
     class Meta:
@@ -38,20 +38,20 @@ class CasesRealDailyNormalisedSerializer(serializers.ModelSerializer):
         fields = (
             "iso_code",
             "date",
-            "cases_per_million",
-            "cumulative_cases_per_million",
+            "weekly_avg_cases_per_million",
+            "summed_avg_cases_per_million",
         )
 
 
 class CasesRealIntegratedSerializer(serializers.ModelSerializer):
     iso_code = serializers.SerializerMethodField()
     date = serializers.SerializerMethodField()
-    total_cases = serializers.SerializerMethodField()
-    total_cases_per_million = serializers.SerializerMethodField()
+    summed_avg_cases = serializers.SerializerMethodField()
+    summed_avg_cases_per_million = serializers.SerializerMethodField()
 
     class Meta:
         model = CasesRecord
-        fields = ("iso_code", "date", "total_cases", "total_cases_per_million")
+        fields = ("iso_code", "date", "summed_avg_cases", "summed_avg_cases_per_million")
 
     def get_iso_code(self, datadict):
         return datadict["country"]
@@ -59,8 +59,8 @@ class CasesRealIntegratedSerializer(serializers.ModelSerializer):
     def get_date(self, datadict):
         return datadict["date"]
 
-    def get_total_cases(self, datadict):
-        return datadict["total_cases"]
+    def get_summed_avg_cases(self, datadict):
+        return datadict["summed_avg_cases"]
 
-    def get_total_cases_per_million(self, datadict):
-        return datadict["total_cases_per_million"]
+    def get_summed_avg_cases_per_million(self, datadict):
+        return datadict["summed_avg_cases_per_million"]

--- a/backend/cases/serializers/ephemeral.py
+++ b/backend/cases/serializers/ephemeral.py
@@ -6,37 +6,37 @@ from countries.models import Country
 class CasesCounterfactualDailyAbsoluteSerializer(serializers.Serializer):
     iso_code = serializers.CharField(max_length=3)
     date = serializers.DateField()
-    cases = serializers.FloatField()
-    cumulative_cases = serializers.FloatField()
+    weekly_avg_cases = serializers.FloatField()
+    summed_avg_cases = serializers.FloatField()
 
 
 class CasesCounterfactualDailyNormalisedSerializer(serializers.Serializer):
     iso_code = serializers.CharField(max_length=3)
     date = serializers.DateField()
-    cases_per_million = serializers.SerializerMethodField()
-    cumulative_cases_per_million = serializers.SerializerMethodField()
+    weekly_avg_cases_per_million = serializers.SerializerMethodField()
+    summed_avg_cases_per_million = serializers.SerializerMethodField()
 
-    def get_cases_per_million(self, entry):
+    def get_weekly_avg_cases_per_million(self, entry):
         if entry["population"] and entry["population"] != 0:
-            return 1e6 * entry["cases"] / entry["population"]
+            return 1e6 * entry["weekly_avg_cases"] / entry["population"]
         return 0
 
-    def get_cumulative_cases_per_million(self, entry):
+    def get_summed_avg_cases_per_million(self, entry):
         if entry["population"] and entry["population"] != 0:
-            return 1e6 * entry["cumulative_cases"] / entry["population"]
+            return 1e6 * entry["summed_avg_cases"] / entry["population"]
         return 0
 
 
 class CasesCounterfactualIntegratedSerializer(serializers.Serializer):
     iso_code = serializers.CharField(max_length=3)
     date = serializers.DateField()
-    total_cases = serializers.SerializerMethodField()
-    total_cases_per_million = serializers.SerializerMethodField()
+    summed_avg_cases = serializers.SerializerMethodField()
+    summed_avg_cases_per_million = serializers.SerializerMethodField()
 
-    def get_total_cases(self, entry):
-        return entry["cumulative_cases"]
+    def get_summed_avg_cases(self, entry):
+        return entry["summed_avg_cases"]
 
-    def get_total_cases_per_million(self, entry):
+    def get_summed_avg_cases_per_million(self, entry):
         if entry["population"] and entry["population"] != 0:
-            return 1e6 * entry["cumulative_cases"] / entry["population"]
+            return 1e6 * entry["summed_avg_cases"] / entry["population"]
         return 0

--- a/backend/cases/views.py
+++ b/backend/cases/views.py
@@ -69,8 +69,8 @@ class CasesCounterfactualIntegratedView(CasesCounterfactualViewMixin, viewsets.V
     serializer_class = CasesCounterfactualIntegratedSerializer
 
     def simulate(self, iso_codes, start_date, end_date):
-        return CounterfactualCasesRecord.simulate_counterfactual_summary_records(
-            iso_codes, start_date, end_date
+        return CounterfactualCasesRecord.simulate_counterfactual_records(
+            iso_codes, start_date, end_date, summary=True
         )
 
 

--- a/backend/cases/views.py
+++ b/backend/cases/views.py
@@ -92,8 +92,8 @@ class CasesRealViewMixin(ABC):
         # We run a window function over all entries, summing `cases` over all previous entries
         # We finish by returning the query ordered by date
         queryset = CasesRecord.objects.annotate(
-            cumulative_cases=Window(
-                expression=Sum("cases"),
+            summed_avg_cases=Window(
+                expression=Sum("weekly_avg_cases"),
                 partition_by=[F("country")],
                 order_by=F("date").asc(),
             )
@@ -134,8 +134,8 @@ class CasesRealIntegratedView(CasesRealViewMixin, viewsets.ModelViewSet):
         # Aggregate by country, calculating total cases and per-capita total cases
         return queryset.values("country").annotate(
             date=Max("date"),
-            total_cases=Sum("cases"),
-            total_cases_per_million=ExpressionWrapper(
-                1e6 * Sum("cases") / F("country__population"), output_field=FloatField()
+            summed_avg_cases=Sum("weekly_avg_cases"),
+            summed_avg_cases_per_million=ExpressionWrapper(
+                1e6 * Sum("weekly_avg_cases") / F("country__population"), output_field=FloatField()
             ),
         )

--- a/backend/scripts/cases_load.py
+++ b/backend/scripts/cases_load.py
@@ -55,7 +55,7 @@ def run():
                 m = CasesRecord(
                     country=country,
                     date=entry.Date,
-                    cases=entry.Daily_cases_MA7,
+                    weekly_avg_cases=entry.Daily_cases_MA7,
                 )
                 m.save()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     restart: always
   frontend:
     build: ./frontend
+    depends_on:
+      - backend
     networks:
       - app
     ports:

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Spinner from "react-bootstrap/Spinner";
 import {
   Bar,
   CartesianGrid,
@@ -11,6 +10,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import Loading from "./Loading";
 import LoadDailyCasesTask from "../tasks/LoadDailyCasesTask";
 
 export default class Histogram extends React.Component {
@@ -68,9 +68,7 @@ export default class Histogram extends React.Component {
         }}
       >
         {this.state.casesData.length === 0 ? (
-          <Spinner animation="grow" variant="info" role="status">
-            <span className="sr-only">Loading...</span>
-          </Spinner>
+          <Loading/>
         ) : (
           <ResponsiveContainer height="95%">
             <ComposedChart data={this.state.casesData}>

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { Container, Row, Col, Card } from "react-bootstrap";
+// import { Container, Row, Col, Card } from "react-bootstrap";
 import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
   Line,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ComposedChart,
-  Bar,
 } from "recharts";
 import LoadDailyCasesTask from "../tasks/LoadDailyCasesTask";
 
@@ -22,103 +23,141 @@ export default class Histogram extends React.Component {
     };
   }
 
-  async componentDidUpdate(prevProps, prevState) {
+  async loadCasesData() {
+    // Retrieve real and counterfactual data in parallel
+    const task = new LoadDailyCasesTask();
+    let [casesReal, casesCounterfactual] = await Promise.all([
+      task.getRealCovidCases(this.props.isoCode),
+      task.getCounterfactualCovidCases(this.props.isoCode),
+    ]);
+    // Combine the two datasets into a single data array
+    let casesData = [];
+    for (let i = 0; i < casesReal.length; i++) {
+      const counterfactual = casesCounterfactual.find(
+        (counterfactual) => counterfactual.date === casesReal[i].date
+      );
+      let record = {
+        date: casesReal[i].date,
+        weekly_avg_real: casesReal[i].weekly_avg_cases_per_million,
+        weekly_avg_counterfactual: counterfactual.weekly_avg_cases_per_million,
+      };
+      casesData.push(record);
+    }
+    // Set the component state to trigger a re-render
+    this.setState({ casesData: casesData });
+  }
+
+
+  async componentDidMount() {
+    await this.loadCasesData();
+  }
+
+  async componentDidUpdate(prevProps) {
     if (this.props.isoCode !== prevProps.isoCode) {
-      // Retrieve real and counterfactual data in parallel
-      const task = new LoadDailyCasesTask();
-      let [casesReal, casesCounterfactual] = await Promise.all([
-        task.getRealCovidCases(this.props.isoCode),
-        task.getCounterfactualCovidCases(this.props.isoCode),
-      ]);
-      // Combine the two datasets into a single data array
-      let casesData = [];
-      for (let i = 0; i < casesReal.length; i++) {
-        const counterfactual = casesCounterfactual.find(
-          (counterfactual) => counterfactual.date === casesReal[i].date
-        );
-        let record = {
-          date: casesReal[i].date,
-          weekly_avg_real: casesReal[i].weekly_avg_cases_per_million,
-          weekly_avg_counterfactual: counterfactual.weekly_avg_cases_per_million,
-        };
-        casesData.push(record);
-      }
-      // Set the component state to trigger a re-render
-      this.setState({ casesData: casesData });
+      await this.loadCasesData();
     }
   }
 
   render() {
     return (
-      <div>
-        {!(this.props.isoCode && this.state.casesData.length > 0) ? (
-          <Card
-            bg={"dark"}
-            style={{ marginTop: 5, marginBottom: 5 }}
-            text={"light"}
-          >
-            <Card.Body>
-              <Card.Text>Select a country</Card.Text>
-            </Card.Body>
-          </Card>
+      <div
+        style={{
+          height: this.props.height,
+        }}
+      >
+        {this.state.casesData.length === 0 ? (
+          <span>{this.props.isoCode}</span>
         ) : (
-          <Container fluid>
-            <Row>
-              <Col style={{ width: "33vw" }}>
-                <Card
-                  style={{ width: "18rem", marginTop: 50, marginBottom: 50 }}
-                  bg={"light"}
-                >
-                  <Card.Body>
-                    <Card.Title>{`${this.props.isoCode}`}</Card.Title>
-                    <Card.Text>
-                      {`Total Cases per Million: ${this.props.summedAvgCases
-                        .toFixed(2)
-                        .toString()}`}
-                    </Card.Text>
-                  </Card.Body>
-                </Card>
-              </Col>
-              <Col style={{ width: "33vw" }}>
-                <ComposedChart
-                  data={this.state.casesData}
-                  width={500}
-                  height={350}
-                  margin={{
-                    top: 20,
-                    right: 20,
-                    bottom: 20,
-                    left: 20,
-                  }}
-                >
-                  <CartesianGrid stroke="#f5f5f5" />
-                  <XAxis dataKey="date" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="weekly_avg_real" fill="#413ea0" />
-                  <Line
-                    type="monotone"
-                    dataKey="weekly_avg_counterfactual"
-                    stroke="#ff7300"
-                  />
-                </ComposedChart>
-              </Col>
-              <Col style={{ width: "33vw" }}>
-                <Card
-                  style={{ width: "18rem", marginTop: 50, marginBottom: 50 }}
-                  bg={"light"}
-                >
-                  <Card.Text>
-                    Any other cases_real/information we might want to add in
-                    here.
-                  </Card.Text>
-                </Card>
-              </Col>
-            </Row>
-          </Container>
+          <ResponsiveContainer height="95%">
+            <ComposedChart
+              data={this.state.casesData}
+            >
+              <CartesianGrid stroke="#f5f5f5" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="weekly_avg_real" fill="#413ea0" />
+              <Line
+                type="monotone"
+                dataKey="weekly_avg_counterfactual"
+                stroke="#ff7300"
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
         )}
       </div>
     );
   }
+
+  // <div
+  //        style={{
+  //          backgroundColor: "#ff0000",
+  //          flex: 1,
+  //          display: "flex",
+  //          alignItems: "stretch", // vertical
+  //          justifyContent: "center", // horizontal
+  //        }}
+  // >
+  //   <span>HISTOGRAM</span>
+  // </div>
+
+  // return (
+  //   <div style={{ height: "100%" }}>
+  //     {!(this.props.isoCode && this.state.casesData.length > 0) ? (
+  //       <Card
+  //         bg={"dark"}
+  //         style={{ height: "80%", width: "100%" }}
+  //         text={"light"}
+  //       >
+  //         <Card.Body>
+  //           <Card.Text>Select a country</Card.Text>
+  //         </Card.Body>
+  //       </Card>
+  //     ) : (
+  //       <Container fluid>
+  //         <Row>
+  //           <Col xs={4} md={3} lg={2}>
+  //             <Card
+  //               style={{
+  //                 width: "100%",
+  //                 marginTop: "10%",
+  //                 marginBottom: "10%",
+  //               }}
+  //               bg={"light"}
+  //             >
+  //               <Card.Body>
+  //                 <Card.Title>{`${this.props.isoCode}`}</Card.Title>
+  //                 <Card.Text>
+  //                   {`Total Cases per Million: ${this.props.summedAvgCases
+  //                     .toFixed(2)
+  //                     .toString()}`}
+  //                 </Card.Text>
+  //               </Card.Body>
+  //             </Card>
+  //           </Col>
+  //           <Col xs={4} md={6} lg={8}>
+
+  //             </div>
+  //           </Col>
+  //           <Col xs={4} md={3} lg={2}>
+  //             <Card
+  //               style={{
+  //                 width: "100%",
+  //                 marginTop: "10%",
+  //                 marginBottom: "10%",
+  //               }}
+  //               bg={"light"}
+  //             >
+  //               <Card.Text>
+  //                 Any other cases_real/information we might want to add in
+  //                 here.
+  //               </Card.Text>
+  //             </Card>
+  //           </Col>
+  //         </Row>
+  //       </Container>
+  //     )}
+  //   </div>
+  // );
 }

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -68,7 +68,7 @@ export default class Histogram extends React.Component {
         }}
       >
         {this.state.casesData.length === 0 ? (
-          <Loading/>
+          <Loading />
         ) : (
           <ResponsiveContainer height="95%">
             <ComposedChart data={this.state.casesData}>

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-// import { Container, Row, Col, Card } from "react-bootstrap";
+import Spinner from "react-bootstrap/Spinner";
 import {
   Bar,
   CartesianGrid,
@@ -47,7 +47,6 @@ export default class Histogram extends React.Component {
     this.setState({ casesData: casesData });
   }
 
-
   async componentDidMount() {
     await this.loadCasesData();
   }
@@ -63,15 +62,18 @@ export default class Histogram extends React.Component {
       <div
         style={{
           height: this.props.height,
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
         }}
       >
         {this.state.casesData.length === 0 ? (
-          <span>{this.props.isoCode}</span>
+          <Spinner animation="grow" variant="info" role="status">
+            <span className="sr-only">Loading...</span>
+          </Spinner>
         ) : (
           <ResponsiveContainer height="95%">
-            <ComposedChart
-              data={this.state.casesData}
-            >
+            <ComposedChart data={this.state.casesData}>
               <CartesianGrid stroke="#f5f5f5" />
               <XAxis dataKey="date" />
               <YAxis />
@@ -89,75 +91,4 @@ export default class Histogram extends React.Component {
       </div>
     );
   }
-
-  // <div
-  //        style={{
-  //          backgroundColor: "#ff0000",
-  //          flex: 1,
-  //          display: "flex",
-  //          alignItems: "stretch", // vertical
-  //          justifyContent: "center", // horizontal
-  //        }}
-  // >
-  //   <span>HISTOGRAM</span>
-  // </div>
-
-  // return (
-  //   <div style={{ height: "100%" }}>
-  //     {!(this.props.isoCode && this.state.casesData.length > 0) ? (
-  //       <Card
-  //         bg={"dark"}
-  //         style={{ height: "80%", width: "100%" }}
-  //         text={"light"}
-  //       >
-  //         <Card.Body>
-  //           <Card.Text>Select a country</Card.Text>
-  //         </Card.Body>
-  //       </Card>
-  //     ) : (
-  //       <Container fluid>
-  //         <Row>
-  //           <Col xs={4} md={3} lg={2}>
-  //             <Card
-  //               style={{
-  //                 width: "100%",
-  //                 marginTop: "10%",
-  //                 marginBottom: "10%",
-  //               }}
-  //               bg={"light"}
-  //             >
-  //               <Card.Body>
-  //                 <Card.Title>{`${this.props.isoCode}`}</Card.Title>
-  //                 <Card.Text>
-  //                   {`Total Cases per Million: ${this.props.summedAvgCases
-  //                     .toFixed(2)
-  //                     .toString()}`}
-  //                 </Card.Text>
-  //               </Card.Body>
-  //             </Card>
-  //           </Col>
-  //           <Col xs={4} md={6} lg={8}>
-
-  //             </div>
-  //           </Col>
-  //           <Col xs={4} md={3} lg={2}>
-  //             <Card
-  //               style={{
-  //                 width: "100%",
-  //                 marginTop: "10%",
-  //                 marginBottom: "10%",
-  //               }}
-  //               bg={"light"}
-  //             >
-  //               <Card.Text>
-  //                 Any other cases_real/information we might want to add in
-  //                 here.
-  //               </Card.Text>
-  //             </Card>
-  //           </Col>
-  //         </Row>
-  //       </Container>
-  //     )}
-  //   </div>
-  // );
 }

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -11,11 +11,7 @@ export default class InfoPanel extends React.Component {
     return (
       <div style={{ display: "flex", alignItems: "center", height: "100%" }}>
         {!this.props.isoCode ? (
-          <Card
-            bg={"dark"}
-            text={"light"}
-            style={{ width: "100%" }}
-          >
+          <Card bg={"dark"} text={"light"} style={{ width: "100%" }}>
             <Card.Body style={{ display: "flex", justifyContent: "center" }}>
               <Card.Text>Select a country</Card.Text>
             </Card.Body>

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -1,0 +1,80 @@
+// import Histogram from "./Histogram";
+import React from "react";
+import Card from "react-bootstrap/Card";
+import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
+import Row from "react-bootstrap/Row";
+import Histogram from "./Histogram";
+
+export default class InfoPanel extends React.Component {
+  render() {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center", // vertical stretch-to-fill
+          justifyContent: "center", // horizontal alignment
+          height: "100%",
+          width: "100%",
+        }}
+      >
+        {!this.props.isoCode ? (
+          <Card
+            bg={"dark"}
+            style={{ height: "100%", width: "100%", margin:"5px" }}
+            text={"light"}
+          >
+            <Card.Body>
+              <Card.Text>Select a country</Card.Text>
+            </Card.Body>
+          </Card>
+        ) : (
+          <Container fluid>
+            <Row>
+              <Col xs={4} md={3} lg={2}>
+                <Card
+                  style={{
+                    width: "100%",
+                    marginTop: "10%",
+                    marginBottom: "10%",
+                  }}
+                  bg={"light"}
+                >
+                  <Card.Body>
+                    <Card.Title>{`${this.props.isoCode}`}</Card.Title>
+                    <Card.Text>
+                      {`Total Cases per Million: ${this.props.summedAvgCases
+                        .toFixed(2)
+                        .toString()}`}
+                    </Card.Text>
+                  </Card.Body>
+                </Card>
+              </Col>
+              <Col xs={4} md={6} lg={8}>
+                <Histogram
+                  isoCode={this.props.isoCode}
+                  height={this.props.height}
+                />
+              </Col>
+              <Col xs={4} md={3} lg={2}>
+                <Card
+                  style={{
+                    width: "100%",
+                    marginTop: "10%",
+                    marginBottom: "10%",
+                  }}
+                  bg={"light"}
+                >
+                  <Card.Text>
+                    Any other cases_real/information we might want to add in
+                    here.
+                  </Card.Text>
+                </Card>
+              </Col>
+            </Row>
+          </Container>
+        )}
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -9,22 +9,14 @@ import Histogram from "./Histogram";
 export default class InfoPanel extends React.Component {
   render() {
     return (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center", // vertical stretch-to-fill
-          justifyContent: "center", // horizontal alignment
-          height: "100%",
-          width: "100%",
-        }}
-      >
+      <div style={{ display: "flex", alignItems: "center", height: "100%" }}>
         {!this.props.isoCode ? (
           <Card
             bg={"dark"}
-            style={{ height: "100%", width: "100%", margin:"5px" }}
             text={"light"}
+            style={{ width: "100%" }}
           >
-            <Card.Body>
+            <Card.Body style={{ display: "flex", justifyContent: "center" }}>
               <Card.Text>Select a country</Card.Text>
             </Card.Body>
           </Card>
@@ -34,7 +26,6 @@ export default class InfoPanel extends React.Component {
               <Col xs={4} md={3} lg={2}>
                 <Card
                   style={{
-                    width: "100%",
                     marginTop: "10%",
                     marginBottom: "10%",
                   }}
@@ -59,7 +50,6 @@ export default class InfoPanel extends React.Component {
               <Col xs={4} md={3} lg={2}>
                 <Card
                   style={{
-                    width: "100%",
                     marginTop: "10%",
                     marginBottom: "10%",
                   }}

--- a/frontend/src/components/Legend.jsx
+++ b/frontend/src/components/Legend.jsx
@@ -16,10 +16,10 @@ const Legend = () => {
           key={item.title}
           style={{
             backgroundColor: item.color,
-            flex: 1,
             display: "flex",
+            flex: 1,
             alignItems: "center", // vertical
-            justifyContent: "center", // horiztontal
+            justifyContent: "center", // horizontal
             color: item.textColor != null ? item.textColor : "black",
             fontWeight: "bolder",
             fontSize: "1em",

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
-import Histogram from "./Histogram";
+import InfoPanel from "./InfoPanel";
 import Legend from "./Legend";
 import Loading from "./Loading";
 import WorldMap from "./WorldMap";
@@ -18,6 +18,7 @@ export default class MainGrid extends React.Component {
       isoCode: null,
       summedAvgCases: null,
       sizeMapComponent: "90vh",
+      sizeHistogramComponent: "10vh",
     };
 
     // Bind the `handleCountryChange` function to allow it to be used by other objects
@@ -42,12 +43,14 @@ export default class MainGrid extends React.Component {
         isoCode: null,
         summedAvgCases: null,
         sizeMapComponent: "90vh",
+        sizeHistogramComponent: "10vh",
       });
     } else {
       this.setState({
         isoCode: iso_code,
         summedAvgCases: summed_avg_cases,
         sizeMapComponent: "65vh",
+        sizeHistogramComponent: "35vh",
       });
     }
   }
@@ -67,15 +70,16 @@ export default class MainGrid extends React.Component {
                   onCountrySelect={this.handleCountryChange}
                 />
               </Col>
-              <Col style={{ padding: "0px" }}>
+              <Col xs={2} style={{ padding: "0px" }}>
                 <Legend />
               </Col>
             </Row>
-            <Row style={{ flex_grow: 1, flex_shrink: 1, flex_basis: "auto" }}>
-              <Col>
-                <Histogram
+            <Row>
+              <Col xs={12} style={{ padding: "0px" }}>
+                <InfoPanel
                   isoCode={this.state.isoCode}
                   summedAvgCases={this.state.summedAvgCases}
+                  height={this.state.sizeHistogramComponent}
                 />
               </Col>
             </Row>

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -12,11 +12,11 @@ export default class MainGrid extends React.Component {
   constructor(props) {
     super(props);
 
-    // Initialize state first
+    // Add component-level state
     this.state = {
       countries: [],
-      currentIsoCode: null,
-      currentTotalCasesText: null,
+      isoCode: null,
+      summedAvgCases: null,
       sizeMapComponent: "90vh",
     };
 
@@ -35,17 +35,20 @@ export default class MainGrid extends React.Component {
   }
 
   // Update the state for a new country
-  handleCountryChange(iso_code, total_cases_text) {
-    console.log(`Selected country is ${iso_code}`);
-
+  handleCountryChange(iso_code, summed_avg_cases) {
+    console.log(`Setting country of interest to ${iso_code}`);
     if (iso_code === this.state.currentIsoCode) {
-      this.setState({ currentIsoCode: null });
-      this.setState({ currentTotalCasesText: null });
-      this.setState({ sizeMapComponent: "90vh" });
+      this.setState({
+        isoCode: null,
+        summedAvgCases: null,
+        sizeMapComponent: "90vh",
+      });
     } else {
-      this.setState({ currentIsoCode: iso_code });
-      this.setState({ currentTotalCasesText: total_cases_text });
-      this.setState({ sizeMapComponent: "65vh" });
+      this.setState({
+        isoCode: iso_code,
+        summedAvgCases: summed_avg_cases,
+        sizeMapComponent: "65vh",
+      });
     }
   }
 
@@ -71,8 +74,8 @@ export default class MainGrid extends React.Component {
             <Row style={{ flex_grow: 1, flex_shrink: 1, flex_basis: "auto" }}>
               <Col>
                 <Histogram
-                  currentIsoCode={this.state.currentIsoCode}
-                  currentTotalCasesText={this.state.currentTotalCasesText}
+                  isoCode={this.state.isoCode}
+                  summedAvgCases={this.state.summedAvgCases}
                 />
               </Col>
             </Row>

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -38,7 +38,7 @@ export default class MainGrid extends React.Component {
   // Update the state for a new country
   handleCountryChange(iso_code, summed_avg_cases) {
     console.log(`Setting country of interest to ${iso_code}`);
-    if (iso_code === this.state.currentIsoCode) {
+    if (iso_code === this.state.isoCode) {
       this.setState({
         isoCode: null,
         summedAvgCases: null,
@@ -74,7 +74,7 @@ export default class MainGrid extends React.Component {
                 <Legend />
               </Col>
             </Row>
-            <Row>
+            <Row style={{ height: this.state.sizeHistogramComponent }}>
               <Col xs={12} style={{ padding: "0px" }}>
                 <InfoPanel
                   isoCode={this.state.isoCode}

--- a/frontend/src/components/WorldMap.jsx
+++ b/frontend/src/components/WorldMap.jsx
@@ -12,14 +12,10 @@ const WorldMap = ({ countries, onCountrySelect }) => {
 
   const onEachCountry = (country, layer) => {
     layer.options.fillColor = country.properties.color;
-    const name = country.properties.name;
-    const totalCasesPerMillionText =
-      country.properties.totalCasesPerMillionText;
-    layer.bindPopup(`${name} ${totalCasesPerMillionText}`);
     layer.on("click", function (e) {
       onCountrySelect(
         e.target.feature.id,
-        e.target.feature.properties.totalCasesPerMillionText
+        e.target.feature.properties.summedAvgCasesPerMillion
       );
     });
   };

--- a/frontend/src/tasks/LoadDailyCasesTask.js
+++ b/frontend/src/tasks/LoadDailyCasesTask.js
@@ -1,0 +1,28 @@
+import axios from "axios";
+
+class LoadDailyCasesTask {
+  #getDailyCovidCases = async (datatype, iso_code) => {
+    try {
+      const res = await axios.get(
+        `http://localhost:8000/api/cases/${datatype}/daily/normalised/?iso_code=${iso_code}&end_date=2020-06-23`,
+        {}
+      );
+      return res.data;
+    } catch (error) {
+      console.log(error);
+      return [];
+    }
+  };
+
+  getCounterfactualCovidCases = async (iso_code) => {
+    const data = await this.#getDailyCovidCases("counterfactual", iso_code);
+    return data;
+  };
+
+  getRealCovidCases = async (iso_code) => {
+    const data = await this.#getDailyCovidCases("real", iso_code);
+    return data;
+  };
+}
+
+export default LoadDailyCasesTask;

--- a/frontend/src/tasks/LoadInitialMapItemsTask.js
+++ b/frontend/src/tasks/LoadInitialMapItemsTask.js
@@ -9,7 +9,7 @@ const loadInitialMapItems = async () => {
   console.log("Preparing map using COVID data...");
   const loadTotalCasesTask = new LoadTotalCasesTask();
   const mapItems = await loadTotalCasesTask.decorateCountries(countries);
-  console.log(`Loaded data for ${mapItems.length} countries`);
+  console.log(`Loaded map data for ${mapItems.length} countries`);
   return mapItems;
 };
 


### PR DESCRIPTION
- Updated backend API to expose `weekly_avg_cases` and `summed_avg_cases`
- Fill frontend histograms using backend data
- Refactored histogram into a separate component from the bottom section (now called `InfoPanel`)
- Fixed some rogue element heights

<img width="1836" alt="Screenshot 2021-02-03 at 19 21 16" src="https://user-images.githubusercontent.com/3502751/106797901-21c8e780-6655-11eb-8b92-0c515c66c3cc.png">

Closes #26.