### PR TITLE
Frontend updates

### DIFF
--- a/backend/dates/views.py
+++ b/backend/dates/views.py
@@ -23,6 +23,15 @@ class ModelDateRangeView(viewsets.ModelViewSet):
     queryset = ModelDateRange.objects.all()  # pylint: disable=no-member
     http_method_names = ["get", "list"]
 
+    def get_queryset(self):
+        """Construct a default queryset with filters"""
+        queryset = ModelDateRange.objects.all()  # pylint: disable=no-member
+        # Apply filter on ISO code
+        iso_code = self.request.query_params.get("iso_code", None)
+        if iso_code:
+            queryset = queryset.filter(country__iso_code=iso_code)
+        return queryset
+
 
 class PossibleDateSetView(viewsets.ModelViewSet):
     """View for PossibleDateSet"""

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react-leaflet": "^3.1.0",
     "react-scripts": "^4.0.3",
     "reactstrap": "8.9.0",
-    "recharts": "^2.0.9"
+    "recharts": "^2.0.9",
+    "react-date-picker": "7.8.1"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -51,15 +51,19 @@ export default class Histogram extends React.Component {
     this.setState({ casesData: casesData });
   }
 
-   async loadRestrictionData() {
-   // Retrieve Restriction data
-   const task = new LoadRestrictionsDatesTask();
-   let [restrictionsDates] = await Promise.all([task.getCountryRestrictionDates(this.props.isoCode)])
+  async loadRestrictionData() {
+    // Retrieve Restriction data
+    const task = new LoadRestrictionsDatesTask();
+    let [restrictionsDates] = await Promise.all([
+      task.getCountryRestrictionDates(this.props.isoCode),
+    ]);
 
-   if (restrictionsDates.length!=0){
-    // Set the component state with the restriction data
-   this.setState({ first_restrictions_date: restrictionsDates[0].first_restrictions_date });
-   this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
+    if (restrictionsDates.length != 0) {
+      // Set the component state with the restriction data
+      this.setState({
+        first_restrictions_date: restrictionsDates[0].first_restrictions_date,
+      });
+      this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
     }
   }
 
@@ -76,7 +80,6 @@ export default class Histogram extends React.Component {
   }
 
   render() {
-
     return (
       <div
         style={{
@@ -102,12 +105,25 @@ export default class Histogram extends React.Component {
                 dataKey="weekly_avg_counterfactual"
                 stroke="#ff7300"
               />
-              if (this.state.first_restrictions_date != null) {
-              <ReferenceLine x={this.state.first_restrictions_date}
-              label={{position: "left", value: "First Restrictions", fontSize: 12}} strokeDasharray="5 5"/>}
-              if (this.state.first_restrictions_date != null) {
-              <ReferenceLine x={this.state.lockdown_date}
-              label={{position: "right", value: "Lockdown", fontSize: 12}} strokeDasharray="5 5"/>
+              if (this.state.first_restrictions_date != null){" "}
+              {
+                <ReferenceLine
+                  x={this.state.first_restrictions_date}
+                  label={{
+                    position: "left",
+                    value: "First Restrictions",
+                    fontSize: 12,
+                  }}
+                  strokeDasharray="5 5"
+                />
+              }
+              if (this.state.first_restrictions_date != null){" "}
+              {
+                <ReferenceLine
+                  x={this.state.lockdown_date}
+                  label={{ position: "right", value: "Lockdown", fontSize: 12 }}
+                  strokeDasharray="5 5"
+                />
               }
             </ComposedChart>
           </ResponsiveContainer>

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -9,9 +9,11 @@ import {
   Tooltip,
   XAxis,
   YAxis,
+  ReferenceLine,
 } from "recharts";
 import Loading from "./Loading";
 import LoadDailyCasesTask from "../tasks/LoadDailyCasesTask";
+import LoadRestrictionsDatesTask from "../tasks/LoadRestrictionsDatesTask.js";
 
 export default class Histogram extends React.Component {
   constructor(props) {
@@ -20,6 +22,9 @@ export default class Histogram extends React.Component {
     // Add component-level state
     this.state = {
       casesData: [],
+      first_restrictions_date: null,
+      lockdown_date: null,
+
     };
   }
 
@@ -47,17 +52,42 @@ export default class Histogram extends React.Component {
     this.setState({ casesData: casesData });
   }
 
-  async componentDidMount() {
+   async loadRestrictionData() {
+   // Retrieve Restriction data
+   const task = new LoadRestrictionsDatesTask();
+   let [restrictionsDates] = await Promise.all([task.getCountryRestrictionDates(this.props.isoCode)])
+
+   console.log('Loading restriction dates')
+   console.log(restrictionsDates[0])
+   console.log(restrictionsDates[0].first_restrictions_date)
+
+    // Set the component state to trigger a re-render
+   this.setState({ first_restrictions_date: restrictionsDates[0].first_restrictions_date });
+   this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
+
+  }
+
+                  
+
+
+ async componentDidMount() {
     await this.loadCasesData();
+    await this.loadRestrictionData();
+
   }
 
   async componentDidUpdate(prevProps) {
     if (this.props.isoCode !== prevProps.isoCode) {
       await this.loadCasesData();
+      await this.loadRestrictionData();
+
     }
   }
 
   render() {
+    console.log('Printing state first restrictions')
+    console.log(this.state.first_restrictions_date)
+    console.log(this.state.lockdown_date)
     return (
       <div
         style={{
@@ -73,7 +103,7 @@ export default class Histogram extends React.Component {
           <ResponsiveContainer height="95%">
             <ComposedChart data={this.state.casesData}>
               <CartesianGrid stroke="#f5f5f5" />
-              <XAxis dataKey="date" />
+              <XAxis dataKey="date"  />
               <YAxis />
               <Tooltip />
               <Legend />
@@ -83,6 +113,10 @@ export default class Histogram extends React.Component {
                 dataKey="weekly_avg_counterfactual"
                 stroke="#ff7300"
               />
+              <ReferenceLine x={this.state.first_restrictions_date}
+              label={{position: "left", value: "First Restrictions", fontSize: 12}} strokeDasharray="5 5"/>
+              <ReferenceLine x={this.state.lockdown_date}
+              label={{position: "right", value: "Lockdown", fontSize: 12}} strokeDasharray="5 5"/>
             </ComposedChart>
           </ResponsiveContainer>
         )}
@@ -90,3 +124,6 @@ export default class Histogram extends React.Component {
     );
   }
 }
+
+
+

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -56,11 +56,10 @@ export default class Histogram extends React.Component {
    const task = new LoadRestrictionsDatesTask();
    let [restrictionsDates] = await Promise.all([task.getCountryRestrictionDates(this.props.isoCode)])
 
-   console.log('Loading restriction dates')
-   console.log(restrictionsDates[0])
-   console.log(restrictionsDates[0].first_restrictions_date)
-
-    // Set the component state to trigger a re-render
+   console.log('restriction dates')
+   console.log(restrictionsDates)
+   if (restrictionsDates.length!=0){
+    // Set the component state with the restriction data
    this.setState({ first_restrictions_date: restrictionsDates[0].first_restrictions_date });
    this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
     }
@@ -79,9 +78,7 @@ export default class Histogram extends React.Component {
   }
 
   render() {
-    console.log('Printing state first restrictions')
-    console.log(this.state.first_restrictions_date)
-    console.log(this.state.lockdown_date)
+
     return (
       <div
         style={{

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -56,8 +56,6 @@ export default class Histogram extends React.Component {
    const task = new LoadRestrictionsDatesTask();
    let [restrictionsDates] = await Promise.all([task.getCountryRestrictionDates(this.props.isoCode)])
 
-   console.log('restriction dates')
-   console.log(restrictionsDates)
    if (restrictionsDates.length!=0){
     // Set the component state with the restriction data
    this.setState({ first_restrictions_date: restrictionsDates[0].first_restrictions_date });

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -91,7 +91,7 @@ export default class Histogram extends React.Component {
         {this.state.casesData.length === 0 ? (
           <Loading />
         ) : (
-          <ResponsiveContainer height="95%">
+          <ResponsiveContainer height="90%">
             <ComposedChart data={this.state.casesData}>
               <CartesianGrid stroke="#f5f5f5" />
               <XAxis dataKey="date" />

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -24,7 +24,6 @@ export default class Histogram extends React.Component {
       casesData: [],
       first_restrictions_date: null,
       lockdown_date: null,
-
     };
   }
 
@@ -52,42 +51,40 @@ export default class Histogram extends React.Component {
     this.setState({ casesData: casesData });
   }
 
-   async loadRestrictionData() {
-   // Retrieve Restriction data
-   const task = new LoadRestrictionsDatesTask();
-   let [restrictionsDates] = await Promise.all([task.getCountryRestrictionDates(this.props.isoCode)])
+  async loadRestrictionData() {
+    // Retrieve Restriction data
+    const task = new LoadRestrictionsDatesTask();
+    let [restrictionsDates] = await Promise.all([
+      task.getCountryRestrictionDates(this.props.isoCode),
+    ]);
 
-   console.log('Loading restriction dates')
-   console.log(restrictionsDates[0])
-   console.log(restrictionsDates[0].first_restrictions_date)
+    console.log("Loading restriction dates");
+    console.log(restrictionsDates[0]);
+    console.log(restrictionsDates[0].first_restrictions_date);
 
     // Set the component state to trigger a re-render
-   this.setState({ first_restrictions_date: restrictionsDates[0].first_restrictions_date });
-   this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
-
+    this.setState({
+      first_restrictions_date: restrictionsDates[0].first_restrictions_date,
+    });
+    this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
   }
 
-                  
-
-
- async componentDidMount() {
+  async componentDidMount() {
     await this.loadCasesData();
     await this.loadRestrictionData();
-
   }
 
   async componentDidUpdate(prevProps) {
     if (this.props.isoCode !== prevProps.isoCode) {
       await this.loadCasesData();
       await this.loadRestrictionData();
-
     }
   }
 
   render() {
-    console.log('Printing state first restrictions')
-    console.log(this.state.first_restrictions_date)
-    console.log(this.state.lockdown_date)
+    console.log("Printing state first restrictions");
+    console.log(this.state.first_restrictions_date);
+    console.log(this.state.lockdown_date);
     return (
       <div
         style={{
@@ -103,7 +100,7 @@ export default class Histogram extends React.Component {
           <ResponsiveContainer height="95%">
             <ComposedChart data={this.state.casesData}>
               <CartesianGrid stroke="#f5f5f5" />
-              <XAxis dataKey="date"  />
+              <XAxis dataKey="date" />
               <YAxis />
               <Tooltip />
               <Legend />
@@ -113,10 +110,20 @@ export default class Histogram extends React.Component {
                 dataKey="weekly_avg_counterfactual"
                 stroke="#ff7300"
               />
-              <ReferenceLine x={this.state.first_restrictions_date}
-              label={{position: "left", value: "First Restrictions", fontSize: 12}} strokeDasharray="5 5"/>
-              <ReferenceLine x={this.state.lockdown_date}
-              label={{position: "right", value: "Lockdown", fontSize: 12}} strokeDasharray="5 5"/>
+              <ReferenceLine
+                x={this.state.first_restrictions_date}
+                label={{
+                  position: "left",
+                  value: "First Restrictions",
+                  fontSize: 12,
+                }}
+                strokeDasharray="5 5"
+              />
+              <ReferenceLine
+                x={this.state.lockdown_date}
+                label={{ position: "right", value: "Lockdown", fontSize: 12 }}
+                strokeDasharray="5 5"
+              />
             </ComposedChart>
           </ResponsiveContainer>
         )}
@@ -124,6 +131,3 @@ export default class Histogram extends React.Component {
     );
   }
 }
-
-
-

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -51,22 +51,19 @@ export default class Histogram extends React.Component {
     this.setState({ casesData: casesData });
   }
 
-  async loadRestrictionData() {
-    // Retrieve Restriction data
-    const task = new LoadRestrictionsDatesTask();
-    let [restrictionsDates] = await Promise.all([
-      task.getCountryRestrictionDates(this.props.isoCode),
-    ]);
+   async loadRestrictionData() {
+   // Retrieve Restriction data
+   const task = new LoadRestrictionsDatesTask();
+   let [restrictionsDates] = await Promise.all([task.getCountryRestrictionDates(this.props.isoCode)])
 
-    console.log("Loading restriction dates");
-    console.log(restrictionsDates[0]);
-    console.log(restrictionsDates[0].first_restrictions_date);
+   console.log('Loading restriction dates')
+   console.log(restrictionsDates[0])
+   console.log(restrictionsDates[0].first_restrictions_date)
 
     // Set the component state to trigger a re-render
-    this.setState({
-      first_restrictions_date: restrictionsDates[0].first_restrictions_date,
-    });
-    this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
+   this.setState({ first_restrictions_date: restrictionsDates[0].first_restrictions_date });
+   this.setState({ lockdown_date: restrictionsDates[0].lockdown_date });
+    }
   }
 
   async componentDidMount() {
@@ -82,9 +79,9 @@ export default class Histogram extends React.Component {
   }
 
   render() {
-    console.log("Printing state first restrictions");
-    console.log(this.state.first_restrictions_date);
-    console.log(this.state.lockdown_date);
+    console.log('Printing state first restrictions')
+    console.log(this.state.first_restrictions_date)
+    console.log(this.state.lockdown_date)
     return (
       <div
         style={{
@@ -110,20 +107,13 @@ export default class Histogram extends React.Component {
                 dataKey="weekly_avg_counterfactual"
                 stroke="#ff7300"
               />
-              <ReferenceLine
-                x={this.state.first_restrictions_date}
-                label={{
-                  position: "left",
-                  value: "First Restrictions",
-                  fontSize: 12,
-                }}
-                strokeDasharray="5 5"
-              />
-              <ReferenceLine
-                x={this.state.lockdown_date}
-                label={{ position: "right", value: "Lockdown", fontSize: 12 }}
-                strokeDasharray="5 5"
-              />
+              if (this.state.first_restrictions_date != null) {
+              <ReferenceLine x={this.state.first_restrictions_date}
+              label={{position: "left", value: "First Restrictions", fontSize: 12}} strokeDasharray="5 5"/>}
+              if (this.state.first_restrictions_date != null) {
+              <ReferenceLine x={this.state.lockdown_date}
+              label={{position: "right", value: "Lockdown", fontSize: 12}} strokeDasharray="5 5"/>
+              }
             </ComposedChart>
           </ResponsiveContainer>
         )}

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -14,32 +14,89 @@ export default class InfoPanel extends React.Component {
         {!this.props.isoCode ? null : (
           <Container fluid>
             <Row>
-              <Col xs={4} md={3} lg={2}>
+              <Col xs={3} md={3} lg={3}>
+                <Row xs={1} md={1} lg={1}>
                 <Card
                   style={{
-                    marginTop: "10%",
-                    marginBottom: "10%",
+                    marginTop: "5%",
+                    marginBottom: "5%",
                   }}
                   bg={"light"}
                 >
                   <Card.Body>
                     <Card.Title>{`${this.props.countryName}`}</Card.Title>
                     <Card.Text>
-                      {`Total Cases per Million: ${this.props.summedAvgCases
-                        .toFixed(2)
-                        .toString()}`}
+                      The first wave for {`${this.props.countryName}`} happened between X and X date.
                     </Card.Text>
                   </Card.Body>
                 </Card>
+                </Row>
+                <Row xs={1} md={1} lg={1}>
+                <Card
+                  style={{
+                    marginTop: "5%",
+                    marginBottom: "5%",
+                  }}
+                  bg={"light"}
+                >
+                  <Card.Body>
+                    <Card.Title>Covid-19 Statistics:</Card.Title>
+                    <Card.Text>
+                      {`Total Cases per Million: ${this.props.summedAvgCases
+                        .toFixed(2)
+                        .toString()} \n `}
+                    </Card.Text>
+                    <Card.Text>
+                      {`Total Deaths per Million: XXX`}
+                    </Card.Text>
+                  </Card.Body>
+                </Card>
+                </Row>
               </Col>
-              <Col xs={4} md={6} lg={8}>
+              <Col xs={6} md={6} lg={6}>
+               <Row  xs={1} md={1} lg={1}>
+                <MyDatesPicker/>
+                </Row>
+                <Row xs={1} md={1} lg={1}>
                 <Histogram
                   isoCode={this.props.isoCode}
                   height={this.props.height}
                 />
+                </Row>
               </Col>
-              <Col xs={4} md={3} lg={2}>
-                <MyDatesPicker />
+              <Col xs={3} md={3} lg={3}>
+               <Row xs={1} md={1} lg={1}>
+                <Card
+                  style={{
+                    marginTop: "5%",
+                    marginBottom: "5%",
+                  }}
+                  bg={"light"}
+                >
+                  <Card.Body>
+                    <Card.Title>Population Density</Card.Title>
+                    <Card.Text>
+                      XXX Density
+                    </Card.Text>
+                  </Card.Body>
+                </Card>
+                </Row>
+                <Row xs={1} md={1} lg={1}>
+                <Card
+                  style={{
+                    marginTop: "5%",
+                    marginBottom: "5%",
+                  }}
+                  bg={"light"}
+                >
+                  <Card.Body>
+                    <Card.Title>XXX</Card.Title>
+                    <Card.Text>
+                      XXX
+                    </Card.Text>
+                  </Card.Body>
+                </Card>
+                </Row>
               </Col>
             </Row>
           </Container>

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -5,7 +5,7 @@ import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Histogram from "./Histogram";
-import MyDatesPicker from "./MyDatesPicker"
+import MyDatesPicker from "./MyDatesPicker";
 
 export default class InfoPanel extends React.Component {
   render() {
@@ -39,7 +39,7 @@ export default class InfoPanel extends React.Component {
                 />
               </Col>
               <Col xs={4} md={3} lg={2}>
-                <MyDatesPicker/>
+                <MyDatesPicker />
               </Col>
             </Row>
           </Container>

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -5,6 +5,7 @@ import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Histogram from "./Histogram";
+import MyDatesPicker from "./MyDatesPicker"
 
 export default class InfoPanel extends React.Component {
   render() {
@@ -38,18 +39,7 @@ export default class InfoPanel extends React.Component {
                 />
               </Col>
               <Col xs={4} md={3} lg={2}>
-                <Card
-                  style={{
-                    marginTop: "10%",
-                    marginBottom: "10%",
-                  }}
-                  bg={"light"}
-                >
-                  <Card.Text>
-                    Any other cases_real/information we might want to add in
-                    here.
-                  </Card.Text>
-                </Card>
+                <MyDatesPicker/>
               </Col>
             </Row>
           </Container>

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -16,86 +16,81 @@ export default class InfoPanel extends React.Component {
             <Row>
               <Col xs={3} md={3} lg={3}>
                 <Row xs={1} md={1} lg={1}>
-                <Card
-                  style={{
-                    marginTop: "5%",
-                    marginBottom: "5%",
-                  }}
-                  bg={"light"}
-                >
-                  <Card.Body>
-                    <Card.Title>{`${this.props.countryName}`}</Card.Title>
-                    <Card.Text>
-                      The first wave for {`${this.props.countryName}`} happened between X and X date.
-                    </Card.Text>
-                  </Card.Body>
-                </Card>
+                  <Card
+                    style={{
+                      marginTop: "5%",
+                      marginBottom: "5%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>{`${this.props.countryName}`}</Card.Title>
+                      <Card.Text>
+                        The first wave for {`${this.props.countryName}`}{" "}
+                        happened between X and X date.
+                      </Card.Text>
+                    </Card.Body>
+                  </Card>
                 </Row>
                 <Row xs={1} md={1} lg={1}>
-                <Card
-                  style={{
-                    marginTop: "5%",
-                    marginBottom: "5%",
-                  }}
-                  bg={"light"}
-                >
-                  <Card.Body>
-                    <Card.Title>Covid-19 Statistics:</Card.Title>
-                    <Card.Text>
-                      {`Total Cases per Million: ${this.props.summedAvgCases
-                        .toFixed(2)
-                        .toString()} \n `}
-                    </Card.Text>
-                    <Card.Text>
-                      {`Total Deaths per Million: XXX`}
-                    </Card.Text>
-                  </Card.Body>
-                </Card>
+                  <Card
+                    style={{
+                      marginTop: "5%",
+                      marginBottom: "5%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>Covid-19 Statistics:</Card.Title>
+                      <Card.Text>
+                        {`Total Cases per Million: ${this.props.summedAvgCases
+                          .toFixed(2)
+                          .toString()} \n `}
+                      </Card.Text>
+                      <Card.Text>{`Total Deaths per Million: XXX`}</Card.Text>
+                    </Card.Body>
+                  </Card>
                 </Row>
               </Col>
               <Col xs={6} md={6} lg={6}>
-               <Row  xs={1} md={1} lg={1}>
-                <MyDatesPicker/>
+                <Row xs={1} md={1} lg={1}>
+                  <MyDatesPicker />
                 </Row>
                 <Row xs={1} md={1} lg={1}>
-                <Histogram
-                  isoCode={this.props.isoCode}
-                  height={this.props.height}
-                />
+                  <Histogram
+                    isoCode={this.props.isoCode}
+                    height={this.props.height}
+                  />
                 </Row>
               </Col>
               <Col xs={3} md={3} lg={3}>
-               <Row xs={1} md={1} lg={1}>
-                <Card
-                  style={{
-                    marginTop: "5%",
-                    marginBottom: "5%",
-                  }}
-                  bg={"light"}
-                >
-                  <Card.Body>
-                    <Card.Title>Population Density</Card.Title>
-                    <Card.Text>
-                      XXX Density
-                    </Card.Text>
-                  </Card.Body>
-                </Card>
+                <Row xs={1} md={1} lg={1}>
+                  <Card
+                    style={{
+                      marginTop: "5%",
+                      marginBottom: "5%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>Population Density</Card.Title>
+                      <Card.Text>XXX Density</Card.Text>
+                    </Card.Body>
+                  </Card>
                 </Row>
                 <Row xs={1} md={1} lg={1}>
-                <Card
-                  style={{
-                    marginTop: "5%",
-                    marginBottom: "5%",
-                  }}
-                  bg={"light"}
-                >
-                  <Card.Body>
-                    <Card.Title>XXX</Card.Title>
-                    <Card.Text>
-                      XXX
-                    </Card.Text>
-                  </Card.Body>
-                </Card>
+                  <Card
+                    style={{
+                      marginTop: "5%",
+                      marginBottom: "5%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>XXX</Card.Title>
+                      <Card.Text>XXX</Card.Text>
+                    </Card.Body>
+                  </Card>
                 </Row>
               </Col>
             </Row>

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -57,8 +57,8 @@ export default class MainGrid extends React.Component {
         isoCode: iso_code,
         countryName: selectedCountry.properties.name,
         summedAvgCases: summed_avg_cases,
-        sizeMapComponent: "50vh",
-        sizeHistogramComponent: "38vh",
+        sizeMapComponent: "45vh",
+        sizeHistogramComponent: "43vh",
       });
     }
   }

--- a/frontend/src/components/MyDatesPicker.jsx
+++ b/frontend/src/components/MyDatesPicker.jsx
@@ -1,30 +1,23 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
-import DatePicker from 'react-date-picker';
+import DatePicker from "react-date-picker";
 
 export default class MyDatesPicker extends React.Component {
   state = {
     date: [new Date(), new Date()],
     dateTwo: [new Date(), new Date()],
-  }
+  };
 
-  onChange = date => this.setState({ date })
-  onChangeTwo = dateTwo => this.setState({ dateTwo })
+  onChange = (date) => this.setState({ date });
+  onChangeTwo = (dateTwo) => this.setState({ dateTwo });
 
   render() {
-
     const { date, dateTwo } = this.state;
 
     return (
       <div>
-        <DatePicker
-          onChange={this.onChange}
-          value={date}
-        />
-        <DatePicker
-          onChange={this.onChangeTwo}
-          value={dateTwo}
-        />
+        <DatePicker onChange={this.onChange} value={date} />
+        <DatePicker onChange={this.onChangeTwo} value={dateTwo} />
       </div>
     );
   }

--- a/frontend/src/components/MyDatesPicker.jsx
+++ b/frontend/src/components/MyDatesPicker.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from "react";
+import ReactDOM from "react-dom";
+import DatePicker from 'react-date-picker';
+
+export default class MyDatesPicker extends React.Component {
+  state = {
+    date: [new Date(), new Date()],
+    dateTwo: [new Date(), new Date()],
+  }
+
+  onChange = date => this.setState({ date })
+  onChangeTwo = dateTwo => this.setState({ dateTwo })
+
+  render() {
+
+    const { date, dateTwo } = this.state;
+
+    return (
+      <div>
+        <DatePicker
+          onChange={this.onChange}
+          value={date}
+        />
+        <DatePicker
+          onChange={this.onChangeTwo}
+          value={dateTwo}
+        />
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/MyDatesPicker.jsx
+++ b/frontend/src/components/MyDatesPicker.jsx
@@ -1,11 +1,10 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import DatePicker from "react-date-picker";
-import DatePicker from 'react-date-picker';
+import DatePicker from "react-date-picker";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
-import {ResponsiveContainer} from "recharts";
-
+import { ResponsiveContainer } from "recharts";
 
 export default class MyDatesPicker extends React.Component {
   state = {
@@ -21,24 +20,19 @@ export default class MyDatesPicker extends React.Component {
 
     return (
       <div
-      style={{
+        style={{
           display: "flex",
           justifyContent: "center",
-          alignItems: "center"
-        }}>
-     <Row>
-      <Col>
-        <DatePicker
-          onChange={this.onChange}
-          value={date}
-        />
-       </Col>
-      <Col>
-        <DatePicker
-          onChange={this.onChangeTwo}
-          value={dateTwo}
-        />
-        </Col>
+          alignItems: "center",
+        }}
+      >
+        <Row>
+          <Col>
+            <DatePicker onChange={this.onChange} value={date} />
+          </Col>
+          <Col>
+            <DatePicker onChange={this.onChangeTwo} value={dateTwo} />
+          </Col>
         </Row>
       </div>
     );

--- a/frontend/src/components/MyDatesPicker.jsx
+++ b/frontend/src/components/MyDatesPicker.jsx
@@ -1,6 +1,11 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import DatePicker from "react-date-picker";
+import DatePicker from 'react-date-picker';
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
+import {ResponsiveContainer} from "recharts";
+
 
 export default class MyDatesPicker extends React.Component {
   state = {
@@ -15,9 +20,26 @@ export default class MyDatesPicker extends React.Component {
     const { date, dateTwo } = this.state;
 
     return (
-      <div>
-        <DatePicker onChange={this.onChange} value={date} />
-        <DatePicker onChange={this.onChangeTwo} value={dateTwo} />
+      <div
+      style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center"
+        }}>
+     <Row>
+      <Col>
+        <DatePicker
+          onChange={this.onChange}
+          value={date}
+        />
+       </Col>
+      <Col>
+        <DatePicker
+          onChange={this.onChangeTwo}
+          value={dateTwo}
+        />
+        </Col>
+        </Row>
       </div>
     );
   }

--- a/frontend/src/tasks/LoadDailyCasesTask.js
+++ b/frontend/src/tasks/LoadDailyCasesTask.js
@@ -4,7 +4,7 @@ class LoadDailyCasesTask {
   #getDailyCovidCases = async (datatype, iso_code) => {
     try {
       const res = await axios.get(
-        `http://localhost:8000/api/cases/${datatype}/daily/normalised/?iso_code=${iso_code}&end_date=2020-06-23`,
+        `http://localhost:8000/api/cases/${datatype}/daily/normalised/?iso_code=${iso_code}&end_date=2020-06-23&start_date=2020-02-20`,
         {}
       );
       return res.data;

--- a/frontend/src/tasks/LoadRestrictionsDatesTask.js
+++ b/frontend/src/tasks/LoadRestrictionsDatesTask.js
@@ -3,7 +3,8 @@ import axios from "axios";
 class LoadRestrictionsDatesTask {
   #getRestrictionDates = async (iso_code) => {
     try {
-      const res = await axios.get(`http://localhost:8000/api/modeldaterange/?iso_code=${iso_code}`,
+      const res = await axios.get(
+        `http://localhost:8000/api/modeldaterange/?iso_code=${iso_code}`,
         {}
       );
       return res.data;
@@ -17,8 +18,6 @@ class LoadRestrictionsDatesTask {
     const data = await this.#getRestrictionDates(iso_code);
     return data;
   };
-
-
 }
 
 export default LoadRestrictionsDatesTask;

--- a/frontend/src/tasks/LoadRestrictionsDatesTask.js
+++ b/frontend/src/tasks/LoadRestrictionsDatesTask.js
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+class LoadRestrictionsDatesTask {
+  #getRestrictionDates = async (iso_code) => {
+    try {
+      const res = await axios.get(`http://localhost:8000/api/modeldaterange/?iso_code=${iso_code}`,
+        {}
+      );
+      return res.data;
+    } catch (error) {
+      console.log(error);
+      return [];
+    }
+  };
+
+  getCountryRestrictionDates = async (iso_code) => {
+    const data = await this.#getRestrictionDates(iso_code);
+    return data;
+  };
+
+
+}
+
+export default LoadRestrictionsDatesTask;


### PR DESCRIPTION
- [x] Adding dates picker (this is just a placeholder and doesn't do anything yet, it will be updated when the dates get connected to the counterfactual simulation endpoint in #76)
- [x] Including country restriction dates information in front end
- [x] Backend minor update: adding querying options in ModelDateRange view (so we can do the next point) 
- [x] Restricting date period shown in histogram to > 20 Feb 2020 (this will change with issue #50 )
- [x] Placeholder component cards for issues #75  and #74
- [x] Reordering of info panel components (preliminary new ordering, this might change again so I haven't worried too much that it is flexible for screen scaling, etc. )