### PR TITLE
Frontend/85 total cases

### DIFF
--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -13,6 +13,7 @@ import {
 } from "recharts";
 import Loading from "./Loading";
 import LoadDailyCasesTask from "../tasks/LoadDailyCasesTask";
+import convert from "./Utils.js"
 
 export default class Histogram extends React.Component {
   constructor(props) {
@@ -156,9 +157,3 @@ export default class Histogram extends React.Component {
   }
 }
 
-function convert(date) {
-  var date = date,
-    mnth = ("0" + (date.getMonth() + 1)).slice(-2),
-    day = ("0" + date.getDate()).slice(-2);
-  return [date.getFullYear(), mnth, day].join("-");
-}

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -13,7 +13,7 @@ import {
 } from "recharts";
 import Loading from "./Loading";
 import LoadDailyCasesTask from "../tasks/LoadDailyCasesTask";
-import convert from "./Utils.js"
+import convert from "./Utils.js";
 
 export default class Histogram extends React.Component {
   constructor(props) {
@@ -156,4 +156,3 @@ export default class Histogram extends React.Component {
     );
   }
 }
-

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -9,6 +9,7 @@ import DatePicker from "react-date-picker";
 import Loading from "./Loading";
 import LoadTotalCasesTask from "../tasks/LoadTotalCasesTask.js";
 import "./InfoPanel.css";
+import convert from "./Utils.js"
 
 export default class InfoPanel extends React.Component {
   constructor(props) {
@@ -393,9 +394,3 @@ export default class InfoPanel extends React.Component {
   }
 }
 
-function convert(inputdate) {
-  var date = inputdate,
-    mnth = ("0" + (inputdate.getMonth() + 1)).slice(-2),
-    day = ("0" + inputdate.getDate()).slice(-2);
-  return [date.getFullYear(), mnth, day].join("-");
-}

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -45,7 +45,7 @@ export default class InfoPanel extends React.Component {
     const maximum_date =
       this.state.maximum_date != null ? this.state.maximum_date : "2020-07-06";
 
-    // reload total real cases only if necesary
+    // reload total real cases only if necessary (when we are loading the general page)
     if (do_real_cases == true) {
       let [realCases] = await Promise.all([
         task.getIntegratedCasesCountryData(this.props.isoCode, maximum_date),
@@ -62,9 +62,7 @@ export default class InfoPanel extends React.Component {
       }
     }
 
-    // converting DateFields that come from the DatePicker to string. If there is no
-    // counterfactual date use the default historical one
-
+    // converting DateFields that come from the DatePicker to string.
     let counterfactual_first_restrictions_date;
 
     if (first_restrictions_date == null) {
@@ -185,10 +183,14 @@ export default class InfoPanel extends React.Component {
     // (comment from Camila: this is a bit hacky and could be improved?)
     this.setState({ updateHistogram: true });
 
+  // make sure that the input date for the load total cases is never null
+    const counterfactual_first_restrictions_date = new_date != null ? new_date : new Date(this.state.first_restrictions_date);
+    const counterfactual_lockdown_date = this.state.counterfactual_lockdown_date != null ? this.state.counterfactual_lockdown_date : new Date(this.state.lockdown_date);
+
     await this.loadTotalCases(
       false,
-      new_date,
-      this.state.counterfactual_lockdown_date
+      counterfactual_first_restrictions_date,
+      counterfactual_lockdown_date
     );
 
     this.setState({ dates_changed: true });
@@ -202,10 +204,14 @@ export default class InfoPanel extends React.Component {
     // set updateHistogram to true to render the new histogram component
     this.setState({ updateHistogram: true });
 
+  // make sure that the input date for the load total cases is never null
+    const counterfactual_first_restrictions_date = this.state.counterfactual_first_restrictions_date != null ? this.state.counterfactual_first_restrictions_date : new Date(this.state.first_restrictions_date);
+    const counterfactual_lockdown_date = new_date != null ? new_date : new Date(this.state.lockdown_date);
+
     await this.loadTotalCases(
       false,
-      this.state.counterfactual_first_restrictions_date,
-      new_date
+      counterfactual_first_restrictions_date,
+      counterfactual_lockdown_date
     );
 
     this.setState({ dates_changed: true });

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -32,6 +32,61 @@ export default class InfoPanel extends React.Component {
     this.onLockdownChange = this.onLockdownChange.bind(this);
   }
 
+  async loadTotalCases(){
+     const task = new LoadTotalCasesTask();
+
+        // if there is not an available start or end date in the data use this default ones
+    const initial_date =
+      this.state.initial_date != null ? this.state.initial_date : "2020-02-20";
+    const maximum_date =
+      this.state.maximum_date != null ? this.state.maximum_date : "2020-07-06";
+
+    // converting DateFields that come from the DatePicker to string. If there is no
+    // counterfactual date use the default historical one
+    const counterfactual_first_restrictions_date =
+      this.props.counterfactual_first_restrictions_date != null
+        ? convert(this.props.counterfactual_first_restrictions_date)
+        : this.props.first_restrictions_date;
+    const counterfactual_lockdown_date =
+      this.props.counterfactual_lockdown_date != null
+        ? convert(this.props.counterfactual_lockdown_date)
+        : this.props.lockdown_date;
+
+     let [conterfactualCases] = await Promise.all([
+      task.getIntegratedCounterfactualCountryData(
+        this.props.isoCode,
+        initial_date,
+        maximum_date,
+        counterfactual_first_restrictions_date,
+        counterfactual_lockdown_date
+       ),
+    ]);
+
+
+     let [realCases] = await Promise.all([
+      task.getIntegratedCasesCountryData(this.props.isoCode,maximum_date),
+    ]);
+
+
+        console.log(realCases)
+
+     if (( realCases != null) & ( conterfactualCases != null)) {
+          console.log(conterfactualCases)
+
+        try{
+        this.setState({
+          total_real_cases: realCases.summed_avg_cases_per_million,
+        });
+        this.setState({ total_counterfactual_cases: conterfactualCases.summed_avg_cases_per_million });
+
+     }
+     catch (error) {
+      console.log(error);
+    }
+     }
+
+  }
+
   async loadRestrictionData() {
     // Retrieve Restriction data
     const task = new LoadRestrictionsDatesTask();
@@ -289,4 +344,11 @@ export default class InfoPanel extends React.Component {
       </div>
     );
   }
+}
+
+function convert(date) {
+  var date = date,
+    mnth = ("0" + (date.getMonth() + 1)).slice(-2),
+    day = ("0" + date.getDate()).slice(-2);
+  return [date.getFullYear(), mnth, day].join("-");
 }

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -9,7 +9,7 @@ import DatePicker from "react-date-picker";
 import Loading from "./Loading";
 import LoadTotalCasesTask from "../tasks/LoadTotalCasesTask.js";
 import "./InfoPanel.css";
-import convert from "./Utils.js"
+import convert from "./Utils.js";
 
 export default class InfoPanel extends React.Component {
   constructor(props) {
@@ -183,9 +183,15 @@ export default class InfoPanel extends React.Component {
     // (comment from Camila: this is a bit hacky and could be improved?)
     this.setState({ updateHistogram: true });
 
-  // make sure that the input date for the load total cases is never null
-    const counterfactual_first_restrictions_date = new_date != null ? new_date : new Date(this.state.first_restrictions_date);
-    const counterfactual_lockdown_date = this.state.counterfactual_lockdown_date != null ? this.state.counterfactual_lockdown_date : new Date(this.state.lockdown_date);
+    // make sure that the input date for the load total cases is never null
+    const counterfactual_first_restrictions_date =
+      new_date != null
+        ? new_date
+        : new Date(this.state.first_restrictions_date);
+    const counterfactual_lockdown_date =
+      this.state.counterfactual_lockdown_date != null
+        ? this.state.counterfactual_lockdown_date
+        : new Date(this.state.lockdown_date);
 
     await this.loadTotalCases(
       false,
@@ -204,9 +210,13 @@ export default class InfoPanel extends React.Component {
     // set updateHistogram to true to render the new histogram component
     this.setState({ updateHistogram: true });
 
-  // make sure that the input date for the load total cases is never null
-    const counterfactual_first_restrictions_date = this.state.counterfactual_first_restrictions_date != null ? this.state.counterfactual_first_restrictions_date : new Date(this.state.first_restrictions_date);
-    const counterfactual_lockdown_date = new_date != null ? new_date : new Date(this.state.lockdown_date);
+    // make sure that the input date for the load total cases is never null
+    const counterfactual_first_restrictions_date =
+      this.state.counterfactual_first_restrictions_date != null
+        ? this.state.counterfactual_first_restrictions_date
+        : new Date(this.state.first_restrictions_date);
+    const counterfactual_lockdown_date =
+      new_date != null ? new_date : new Date(this.state.lockdown_date);
 
     await this.loadTotalCases(
       false,
@@ -399,4 +409,3 @@ export default class InfoPanel extends React.Component {
     );
   }
 }
-

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -23,8 +23,7 @@ export default class InfoPanel extends React.Component {
       maximum_date: null,
       updateHistogram: false,
       total_real_cases: null,
-      total_counterfactual_cases: null
-
+      total_counterfactual_cases: null,
     };
 
     // Bind the datepicker change functions to allow it to be used by other objects
@@ -32,10 +31,10 @@ export default class InfoPanel extends React.Component {
     this.onLockdownChange = this.onLockdownChange.bind(this);
   }
 
-  async loadTotalCases(){
-     const task = new LoadTotalCasesTask();
+  async loadTotalCases() {
+    const task = new LoadTotalCasesTask();
 
-        // if there is not an available start or end date in the data use this default ones
+    // if there is not an available start or end date in the data use this default ones
     const initial_date =
       this.state.initial_date != null ? this.state.initial_date : "2020-02-20";
     const maximum_date =
@@ -52,39 +51,37 @@ export default class InfoPanel extends React.Component {
         ? convert(this.props.counterfactual_lockdown_date)
         : this.props.lockdown_date;
 
-     let [conterfactualCases] = await Promise.all([
+    let [conterfactualCases] = await Promise.all([
       task.getIntegratedCounterfactualCountryData(
         this.props.isoCode,
         initial_date,
         maximum_date,
         counterfactual_first_restrictions_date,
         counterfactual_lockdown_date
-       ),
+      ),
     ]);
 
-
-     let [realCases] = await Promise.all([
-      task.getIntegratedCasesCountryData(this.props.isoCode,maximum_date),
+    let [realCases] = await Promise.all([
+      task.getIntegratedCasesCountryData(this.props.isoCode, maximum_date),
     ]);
 
+    console.log(realCases);
 
-        console.log(realCases)
+    if ((realCases != null) & (conterfactualCases != null)) {
+      console.log(conterfactualCases);
 
-     if (( realCases != null) & ( conterfactualCases != null)) {
-          console.log(conterfactualCases)
-
-        try{
+      try {
         this.setState({
           total_real_cases: realCases.summed_avg_cases_per_million,
         });
-        this.setState({ total_counterfactual_cases: conterfactualCases.summed_avg_cases_per_million });
-
-     }
-     catch (error) {
-      console.log(error);
+        this.setState({
+          total_counterfactual_cases:
+            conterfactualCases.summed_avg_cases_per_million,
+        });
+      } catch (error) {
+        console.log(error);
+      }
     }
-     }
-
   }
 
   async loadRestrictionData() {
@@ -149,7 +146,6 @@ export default class InfoPanel extends React.Component {
 
       await this.loadRestrictionData();
       await this.loadTotalCases();
-
     }
   }
 
@@ -220,13 +216,13 @@ export default class InfoPanel extends React.Component {
                   >
                     <Card.Body>
                       <Card.Title>Statistics</Card.Title>
-                       {!this.state.total_real_cases ? null : (
-                      <Card.Text>
-                        {`Total COVID-19 Cases per Million: ${this.state.total_real_cases
-                          .toFixed(0)
-                          .toString()} \n `}
-                      </Card.Text>
-                       )}
+                      {!this.state.total_real_cases ? null : (
+                        <Card.Text>
+                          {`Total COVID-19 Cases per Million: ${this.state.total_real_cases
+                            .toFixed(0)
+                            .toString()} \n `}
+                        </Card.Text>
+                      )}
                       <Card.Text>{`Total COVID-19 Deaths per Million: XXX`}</Card.Text>
                       <Card.Text>{`Population density: XXX`}</Card.Text>
                     </Card.Body>
@@ -327,12 +323,12 @@ export default class InfoPanel extends React.Component {
                     <Card.Body>
                       <Card.Title>Counterfactual Statistics</Card.Title>
                       {!this.state.total_counterfactual_cases ? null : (
-                      <Card.Text>
-                        {`Total COVID-19 Cases per Million: ${this.state.total_counterfactual_cases
-                          .toFixed(0)
-                         .toString()} \n `}
-                      </Card.Text>
-                        )}
+                        <Card.Text>
+                          {`Total COVID-19 Cases per Million: ${this.state.total_counterfactual_cases
+                            .toFixed(0)
+                            .toString()} \n `}
+                        </Card.Text>
+                      )}
                       <Card.Text>{`% reduction in total cases`}</Card.Text>
                     </Card.Body>
                   </Card>

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -1,350 +1,395 @@
-import React from "react";
-import Card from "react-bootstrap/Card";
-import Col from "react-bootstrap/Col";
-import Container from "react-bootstrap/Container";
-import Row from "react-bootstrap/Row";
-import Histogram from "./Histogram";
-import LoadRestrictionsDatesTask from "../tasks/LoadRestrictionsDatesTask.js";
-import DatePicker from "react-date-picker";
-import Loading from "./Loading";
-import LoadTotalCasesTask from "../tasks/LoadTotalCasesTask.js";
-import "./InfoPanel.css";
+    import React from "react";
+    import Card from "react-bootstrap/Card";
+    import Col from "react-bootstrap/Col";
+    import Container from "react-bootstrap/Container";
+    import Row from "react-bootstrap/Row";
+    import Histogram from "./Histogram";
+    import LoadRestrictionsDatesTask from "../tasks/LoadRestrictionsDatesTask.js";
+    import DatePicker from "react-date-picker";
+    import Loading from "./Loading";
+    import LoadTotalCasesTask from "../tasks/LoadTotalCasesTask.js";
+    import "./InfoPanel.css";
 
-export default class InfoPanel extends React.Component {
-  constructor(props) {
-    super(props);
+    export default class InfoPanel extends React.Component {
+      constructor(props) {
+        super(props);
 
-    this.state = {
-      first_restrictions_date: null,
-      lockdown_date: null,
-      counterfactual_first_restrictions_date: null,
-      counterfactual_lockdown_date: null,
-      initial_date: null,
-      maximum_date: null,
-      updateHistogram: false,
-      total_real_cases: null,
-      total_counterfactual_cases: null,
-    };
+        this.state = {
+          first_restrictions_date: null,
+          lockdown_date: null,
+          counterfactual_first_restrictions_date: null,
+          counterfactual_lockdown_date: null,
+          initial_date: null,
+          maximum_date: null,
+          updateHistogram: false,
+          total_real_cases: null,
+          total_counterfactual_cases: null,
+          dates_changed: false
 
-    // Bind the datepicker change functions to allow it to be used by other objects
-    this.onFirstRestrictionsChange = this.onFirstRestrictionsChange.bind(this);
-    this.onLockdownChange = this.onLockdownChange.bind(this);
-  }
+        };
 
-  async loadTotalCases() {
-    const task = new LoadTotalCasesTask();
-
-    // if there is not an available start or end date in the data use this default ones
-    const initial_date =
-      this.state.initial_date != null ? this.state.initial_date : "2020-02-20";
-    const maximum_date =
-      this.state.maximum_date != null ? this.state.maximum_date : "2020-07-06";
-
-    // converting DateFields that come from the DatePicker to string. If there is no
-    // counterfactual date use the default historical one
-    const counterfactual_first_restrictions_date =
-      this.props.counterfactual_first_restrictions_date != null
-        ? convert(this.props.counterfactual_first_restrictions_date)
-        : this.props.first_restrictions_date;
-    const counterfactual_lockdown_date =
-      this.props.counterfactual_lockdown_date != null
-        ? convert(this.props.counterfactual_lockdown_date)
-        : this.props.lockdown_date;
-
-    let [conterfactualCases] = await Promise.all([
-      task.getIntegratedCounterfactualCountryData(
-        this.props.isoCode,
-        initial_date,
-        maximum_date,
-        counterfactual_first_restrictions_date,
-        counterfactual_lockdown_date
-      ),
-    ]);
-
-    let [realCases] = await Promise.all([
-      task.getIntegratedCasesCountryData(this.props.isoCode, maximum_date),
-    ]);
-
-    console.log(realCases);
-
-    if ((realCases != null) & (conterfactualCases != null)) {
-      console.log(conterfactualCases);
-
-      try {
-        this.setState({
-          total_real_cases: realCases.summed_avg_cases_per_million,
-        });
-        this.setState({
-          total_counterfactual_cases:
-            conterfactualCases.summed_avg_cases_per_million,
-        });
-      } catch (error) {
-        console.log(error);
+        // Bind the datepicker change functions to allow it to be used by other objects
+        this.onFirstRestrictionsChange = this.onFirstRestrictionsChange.bind(this);
+        this.onLockdownChange = this.onLockdownChange.bind(this);
       }
-    }
-  }
 
-  async loadRestrictionData() {
-    // Retrieve Restriction data
-    const task = new LoadRestrictionsDatesTask();
-    let [restrictionsDates] = await Promise.all([
-      task.getCountryRestrictionDates(this.props.isoCode),
-    ]);
+      async loadTotalCases(do_real_cases, first_restrictions_date = null, lockdown_date= null){
 
-    if ((restrictionsDates != null) & (this.props.isoCode != null)) {
-      try {
-        // Set the component state with the restriction data
-        this.setState({
-          first_restrictions_date: restrictionsDates.first_restrictions_date,
-        });
-        this.setState({ lockdown_date: restrictionsDates.lockdown_date });
-        this.setState({ initial_date: restrictionsDates.initial_date });
-        this.setState({ maximum_date: restrictionsDates.maximum_date });
+        const task = new LoadTotalCasesTask();
+        // if there is not an available start or end date in the data use this default ones
+        const initial_date =
+          this.state.initial_date != null ? this.state.initial_date : "2020-02-20";
+        const maximum_date =
+          this.state.maximum_date != null ? this.state.maximum_date : "2020-07-06";
 
-        // we only update counterfactual if we change countries
-        // set them to their actual restriction dates
+         // reload total real cases only if necesary
+         if (do_real_cases == true){
+         let [realCases] = await Promise.all([
+          task.getIntegratedCasesCountryData(this.props.isoCode,maximum_date),
+        ]);
 
-        if (this.state.first_restrictions_date != null) {
-          // for the datepicker to work this needs to be a Date object.
-          this.setState({
-            counterfactual_first_restrictions_date: new Date(
-              this.state.first_restrictions_date
-            ),
-          });
+        if (( realCases != null) ) {
+           try{
+            this.setState({
+              total_real_cases: realCases.summed_avg_cases_per_million,
+         });
+
+        }catch (error) {
+          console.log(error);
         }
-        if (this.state.lockdown_date != null) {
-          // for the datepicker to work this needs to be a Date object.
-          this.setState({
-            counterfactual_lockdown_date: new Date(this.state.lockdown_date),
-          });
         }
 
-        // set flag updateHistogram to true in order to render the histogram
+      }
+
+
+        // converting DateFields that come from the DatePicker to string. If there is no
+        // counterfactual date use the default historical one
+
+        let counterfactual_first_restrictions_date;
+
+        if (first_restrictions_date == null){
+            counterfactual_first_restrictions_date = convert(this.state.counterfactual_first_restrictions_date)
+        }
+        else{
+             counterfactual_first_restrictions_date = convert(first_restrictions_date)
+        }
+
+         let counterfactual_lockdown_date;
+
+         if (lockdown_date == null){
+            counterfactual_lockdown_date = convert(this.state.counterfactual_lockdown_date)
+        }
+        else{
+             counterfactual_lockdown_date = convert(lockdown_date)
+        }
+
+
+         let [conterfactualCases] = await Promise.all([
+          task.getIntegratedCounterfactualCountryData(
+            this.props.isoCode,
+            initial_date,
+            maximum_date,
+            counterfactual_first_restrictions_date,
+            counterfactual_lockdown_date
+           ),
+        ]);
+
+
+         if (( conterfactualCases != null)) {
+            try{
+            this.setState({ total_counterfactual_cases: conterfactualCases.summed_avg_cases_per_million });
+         }
+         catch (error) {
+          console.log(error);
+         }
+         }
+
+      }
+
+      async loadRestrictionData() {
+        // Retrieve Restriction data
+        const task = new LoadRestrictionsDatesTask();
+        let [restrictionsDates] = await Promise.all([
+          task.getCountryRestrictionDates(this.props.isoCode),
+        ]);
+
+        if ((restrictionsDates != null) & (this.props.isoCode != null)) {
+          try {
+            // Set the component state with the restriction data
+            this.setState({
+              first_restrictions_date: restrictionsDates.first_restrictions_date,
+            });
+            this.setState({ lockdown_date: restrictionsDates.lockdown_date });
+            this.setState({ initial_date: restrictionsDates.initial_date });
+            this.setState({ maximum_date: restrictionsDates.maximum_date });
+
+            // we only update counterfactual if we change countries
+            // set them to their actual restriction dates
+
+            if (this.state.first_restrictions_date != null) {
+              // for the datepicker to work this needs to be a Date object.
+              this.setState({
+                counterfactual_first_restrictions_date: new Date(
+                  this.state.first_restrictions_date
+                ),
+              });
+            }
+            if (this.state.lockdown_date != null) {
+              // for the datepicker to work this needs to be a Date object.
+              this.setState({
+                counterfactual_lockdown_date: new Date(this.state.lockdown_date),
+              });
+            }
+
+            // set flag updateHistogram to true in order to render the histogram
+            this.setState({ updateHistogram: true });
+          } catch (error) {
+            console.log(error);
+          }
+        }
+      }
+
+      // this runs when the info panel is first mounted
+      async componentDidMount() {
+
+        await this.loadRestrictionData();
+        await this.loadTotalCases(true);
+
+      }
+
+      // this runs when we click in a new country, reload all date information
+      async componentDidUpdate(prevProps) {
+        if (this.props.isoCode !== prevProps.isoCode) {
+          this.setState({ first_restrictions_date: null });
+          this.setState({ lockdown_date: null });
+          this.setState({ initial_date: null });
+          this.setState({ maximum_date: null });
+          this.setState({ counterfactual_first_restrictions_date: null });
+          this.setState({ counterfactual_lockdown_date: null });
+          this.setState({ updateHistogram: false });
+          this.setState({ total_real_cases: false });
+          this.setState({ total_counterfactual_cases: false });
+          this.setState({ dates_changed: false });
+
+
+          await this.loadRestrictionData();
+          await this.loadTotalCases(true);
+
+        }
+
+      }
+
+      // this runs when we change the first restrictions counterfactual date
+      async onFirstRestrictionsChange(new_date) {
+        // set updateHistogram to false to clean the histogram component
+        this.setState({ updateHistogram: false });
+        this.setState({ counterfactual_first_restrictions_date: new_date });
+
+        // set updateHistogram to true to render the new histogram component
+        // (comment from Camila: this is a bit hacky and could be improved?)
         this.setState({ updateHistogram: true });
-      } catch (error) {
-        console.log(error);
+
+        await this.loadTotalCases(false, new_date, this.state.counterfactual_lockdown_date)
+
+        this.setState({ dates_changed: true });
+
+
+      }
+
+      // this runs when we change the lockdown counterfactual date
+       async onLockdownChange(new_date) {
+        // set updateHistogram to false to clean the histogram component
+        this.setState({ updateHistogram: false });
+        this.setState({ counterfactual_lockdown_date: new_date });
+        // set updateHistogram to true to render the new histogram component
+        this.setState({ updateHistogram: true });
+
+        await this.loadTotalCases(false, this.state.counterfactual_first_restrictions_date, new_date)
+
+        this.setState({ dates_changed: true });
+
+      }
+
+      render() {
+        return (
+          <div>
+            {!this.props.isoCode ? null : (
+              <Container fluid>
+                <Row>
+                  <Col xs={3} md={3} lg={3}>
+                    <Row xs={1} md={1} lg={1}>
+                      <Card
+                        style={{
+                          marginTop: "1%",
+                          marginBottom: "1%",
+                        }}
+                        bg={"light"}
+                      >
+                        <Card.Body>
+                          <Card.Title>{`${this.props.countryName}`}</Card.Title>
+                          <Card.Text>First case confimed: XXXX</Card.Text>
+                          <Card.Text>
+                            {" "}
+                            First social distance restrictions:{" "}
+                            {`${this.state.first_restrictions_date}`}.
+                          </Card.Text>
+
+                          {!this.state.lockdown_date ? null : (
+                            <Card.Text>
+                              National lockdown: {` ${this.state.lockdown_date}`}.
+                            </Card.Text>
+                          )}
+                          <Card.Text>
+                            The first wave ended:
+                            {` ${this.state.maximum_date}`}.
+                          </Card.Text>
+                        </Card.Body>
+                      </Card>
+                    </Row>
+                    <Row xs={1} md={1} lg={1}>
+                      <Card
+                        style={{
+                          marginTop: "1%",
+                          marginBottom: "1%",
+                        }}
+                        bg={"light"}
+                      >
+                        <Card.Body>
+                          <Card.Title>Statistics</Card.Title>
+                           {!this.state.total_real_cases ? null : (
+                          <Card.Text>
+                            {`Total COVID-19 Cases per Million: ${this.state.total_real_cases
+                              .toFixed(0)
+                              .toString()} \n `}
+                          </Card.Text>
+                           )}
+                          <Card.Text>{`Total COVID-19 Deaths per Million: XXX`}</Card.Text>
+                          <Card.Text>{`Population density: XXX`}</Card.Text>
+                        </Card.Body>
+                      </Card>
+                    </Row>
+                  </Col>
+                  <Col xs={6} md={6} lg={6}>
+                    <Row xs={1} md={1} lg={1}>
+                      <Row
+                        style={{
+                          display: "flex",
+                          justifyContent: "center",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Col>
+                          <DatePicker
+                            onChange={this.onFirstRestrictionsChange}
+                            value={
+                              this.state.counterfactual_first_restrictions_date
+                            }
+                            format="dd/MM/yyyy"
+                            popperPlacement="bottom-end"
+                            className="form-control"
+                            monthsShown={1}
+                            popperPlacement="bottom"
+                          />
+                        </Col>
+                        <Col>
+                          <DatePicker
+                            onChange={this.onLockdownChange}
+                            value={this.state.counterfactual_lockdown_date}
+                            format="dd/MM/yyyy"
+                            className="form-control"
+                            monthsShown={1}
+                            popperPlacement="bottom"
+                          />
+                        </Col>
+                      </Row>
+                    </Row>
+                    {this.state.updateHistogram === false ? (
+                      <Loading />
+                    ) : (
+                      <Row xs={1} md={1} lg={1}>
+                        <Histogram
+                          isoCode={this.props.isoCode}
+                          height={this.props.height}
+                          initial_date={this.state.initial_date}
+                          maximum_date={this.state.maximum_date}
+                          first_restrictions_date={
+                            this.state.first_restrictions_date
+                          }
+                          lockdown_date={this.state.lockdown_date}
+                          counterfactual_first_restrictions_date={
+                            this.state.counterfactual_first_restrictions_date
+                          }
+                          counterfactual_lockdown_date={
+                            this.state.counterfactual_lockdown_date
+                          }
+                        />
+                      </Row>
+                    )}
+                  </Col>
+                  <Col xs={3} md={3} lg={3}>
+                    <Row xs={1} md={1} lg={1}>
+                      <Card
+                        style={{
+                          marginTop: "1%",
+                          marginBottom: "1%",
+                        }}
+                        bg={"light"}
+                      >
+                        <Card.Body>
+                          <Card.Title>Counterfactual story</Card.Title>
+                          <Card.Text>
+                            Use the calendars to select counterfactual dates for
+                            first social distance restrictions (left) and/or
+                            lockdown (right).
+                          </Card.Text>
+                          <Card.Text> Shift first restrictions: XXX </Card.Text>
+                          <Card.Text> Shift lockdown: XXX </Card.Text>
+                          <Card.Text>
+                            The counterfactual growth is simulated between{" "}
+                            {`${this.state.initial_date}`} and{" "}
+                            {`${this.state.maximum_date}`}.{" "}
+                          </Card.Text>
+                        </Card.Body>
+                      </Card>
+                    </Row>
+                    <Row xs={1} md={1} lg={1}>
+                      <Card
+                        style={{
+                          marginTop: "1%",
+                          marginBottom: "1%",
+                        }}
+                        bg={"light"}
+                      >
+                        <Card.Body>
+                          <Card.Title>Counterfactual Statistics</Card.Title>
+                          {!this.state.total_counterfactual_cases ? null : (
+                          <Card.Text>
+                            {`Total COVID-19 Cases per Million: ${this.state.total_counterfactual_cases
+                              .toFixed(0)
+                             .toString()} \n `}
+                          </Card.Text>
+                            )}
+                           {this.state.dates_changed== false ? null : (
+                          <Card.Text>{`Reduction in total cases: ${((1-this.state.total_counterfactual_cases/this.state.total_real_cases)*100)
+                              .toFixed(1)
+                             .toString()} %\n `}
+                           </Card.Text>
+                          )}
+                        </Card.Body>
+                      </Card>
+                    </Row>
+                  </Col>
+                </Row>
+              </Container>
+            )}
+          </div>
+        );
       }
     }
-  }
 
-  // this runs when the info panel is first mounted
-  async componentDidMount() {
-    await this.loadRestrictionData();
-    await this.loadTotalCases();
-  }
-
-  // this runs when we click in a new country, reload all date information
-  async componentDidUpdate(prevProps) {
-    if (this.props.isoCode !== prevProps.isoCode) {
-      this.setState({ first_restrictions_date: null });
-      this.setState({ lockdown_date: null });
-      this.setState({ initial_date: null });
-      this.setState({ maximum_date: null });
-      this.setState({ counterfactual_first_restrictions_date: null });
-      this.setState({ counterfactual_lockdown_date: null });
-      this.setState({ updateHistogram: false });
-
-      await this.loadRestrictionData();
-      await this.loadTotalCases();
+    function convert(inputdate) {
+      var date = inputdate,
+        mnth = ("0" + (inputdate.getMonth() + 1)).slice(-2),
+        day = ("0" + inputdate.getDate()).slice(-2);
+      return [date.getFullYear(), mnth, day].join("-");
     }
-  }
-
-  // this runs when we change the first restrictions counterfactual date
-  onFirstRestrictionsChange(new_date) {
-    // set updateHistogram to false to clean the histogram component
-    this.setState({ updateHistogram: false });
-    this.setState({ counterfactual_first_restrictions_date: new_date });
-
-    // set updateHistogram to true to render the new histogram component
-    // (comment from Camila: this is a bit hacky and could be improved?)
-    this.setState({ updateHistogram: true });
-  }
-
-  // this runs when we change the lockdown counterfactual date
-  onLockdownChange(new_date) {
-    // set updateHistogram to false to clean the histogram component
-    this.setState({ updateHistogram: false });
-    this.setState({ counterfactual_lockdown_date: new_date });
-
-    // set updateHistogram to true to render the new histogram component
-    this.setState({ updateHistogram: true });
-  }
-
-  render() {
-    return (
-      <div>
-        {!this.props.isoCode ? null : (
-          <Container fluid>
-            <Row>
-              <Col xs={3} md={3} lg={3}>
-                <Row xs={1} md={1} lg={1}>
-                  <Card
-                    style={{
-                      marginTop: "1%",
-                      marginBottom: "1%",
-                    }}
-                    bg={"light"}
-                  >
-                    <Card.Body>
-                      <Card.Title>{`${this.props.countryName}`}</Card.Title>
-                      <Card.Text>First case confimed: XXXX</Card.Text>
-                      <Card.Text>
-                        {" "}
-                        First social distance restrictions:{" "}
-                        {`${this.state.first_restrictions_date}`}.
-                      </Card.Text>
-
-                      {!this.state.lockdown_date ? null : (
-                        <Card.Text>
-                          National lockdown: {` ${this.state.lockdown_date}`}.
-                        </Card.Text>
-                      )}
-                      <Card.Text>
-                        The first wave ended:
-                        {` ${this.state.maximum_date}`}.
-                      </Card.Text>
-                    </Card.Body>
-                  </Card>
-                </Row>
-                <Row xs={1} md={1} lg={1}>
-                  <Card
-                    style={{
-                      marginTop: "1%",
-                      marginBottom: "1%",
-                    }}
-                    bg={"light"}
-                  >
-                    <Card.Body>
-                      <Card.Title>Statistics</Card.Title>
-                      {!this.state.total_real_cases ? null : (
-                        <Card.Text>
-                          {`Total COVID-19 Cases per Million: ${this.state.total_real_cases
-                            .toFixed(0)
-                            .toString()} \n `}
-                        </Card.Text>
-                      )}
-                      <Card.Text>{`Total COVID-19 Deaths per Million: XXX`}</Card.Text>
-                      <Card.Text>{`Population density: XXX`}</Card.Text>
-                    </Card.Body>
-                  </Card>
-                </Row>
-              </Col>
-              <Col xs={6} md={6} lg={6}>
-                <Row xs={1} md={1} lg={1}>
-                  <Row
-                    style={{
-                      display: "flex",
-                      justifyContent: "center",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Col>
-                      <DatePicker
-                        onChange={this.onFirstRestrictionsChange}
-                        value={
-                          this.state.counterfactual_first_restrictions_date
-                        }
-                        format="dd/MM/yyyy"
-                        popperPlacement="bottom-end"
-                        className="form-control"
-                        monthsShown={1}
-                        popperPlacement="bottom"
-                      />
-                    </Col>
-                    <Col>
-                      <DatePicker
-                        onChange={this.onLockdownChange}
-                        value={this.state.counterfactual_lockdown_date}
-                        format="dd/MM/yyyy"
-                        className="form-control"
-                        monthsShown={1}
-                        popperPlacement="bottom"
-                      />
-                    </Col>
-                  </Row>
-                </Row>
-                {this.state.updateHistogram === false ? (
-                  <Loading />
-                ) : (
-                  <Row xs={1} md={1} lg={1}>
-                    <Histogram
-                      isoCode={this.props.isoCode}
-                      height={this.props.height}
-                      initial_date={this.state.initial_date}
-                      maximum_date={this.state.maximum_date}
-                      first_restrictions_date={
-                        this.state.first_restrictions_date
-                      }
-                      lockdown_date={this.state.lockdown_date}
-                      counterfactual_first_restrictions_date={
-                        this.state.counterfactual_first_restrictions_date
-                      }
-                      counterfactual_lockdown_date={
-                        this.state.counterfactual_lockdown_date
-                      }
-                    />
-                  </Row>
-                )}
-              </Col>
-              <Col xs={3} md={3} lg={3}>
-                <Row xs={1} md={1} lg={1}>
-                  <Card
-                    style={{
-                      marginTop: "1%",
-                      marginBottom: "1%",
-                    }}
-                    bg={"light"}
-                  >
-                    <Card.Body>
-                      <Card.Title>Counterfactual story</Card.Title>
-                      <Card.Text>
-                        Use the calendars to select counterfactual dates for
-                        first social distance restrictions (left) and/or
-                        lockdown (right).
-                      </Card.Text>
-                      <Card.Text> Shift first restrictions: XXX </Card.Text>
-                      <Card.Text> Shift lockdown: XXX </Card.Text>
-                      <Card.Text>
-                        The counterfactual growth is simulated between{" "}
-                        {`${this.state.initial_date}`} and{" "}
-                        {`${this.state.maximum_date}`}.{" "}
-                      </Card.Text>
-                    </Card.Body>
-                  </Card>
-                </Row>
-                <Row xs={1} md={1} lg={1}>
-                  <Card
-                    style={{
-                      marginTop: "1%",
-                      marginBottom: "1%",
-                    }}
-                    bg={"light"}
-                  >
-                    <Card.Body>
-                      <Card.Title>Counterfactual Statistics</Card.Title>
-                      {!this.state.total_counterfactual_cases ? null : (
-                        <Card.Text>
-                          {`Total COVID-19 Cases per Million: ${this.state.total_counterfactual_cases
-                            .toFixed(0)
-                            .toString()} \n `}
-                        </Card.Text>
-                      )}
-                      <Card.Text>{`% reduction in total cases`}</Card.Text>
-                    </Card.Body>
-                  </Card>
-                </Row>
-              </Col>
-            </Row>
-          </Container>
-        )}
-      </div>
-    );
-  }
-}
-
-function convert(date) {
-  var date = date,
-    mnth = ("0" + (date.getMonth() + 1)).slice(-2),
-    day = ("0" + date.getDate()).slice(-2);
-  return [date.getFullYear(), mnth, day].join("-");
-}

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -1,395 +1,401 @@
-    import React from "react";
-    import Card from "react-bootstrap/Card";
-    import Col from "react-bootstrap/Col";
-    import Container from "react-bootstrap/Container";
-    import Row from "react-bootstrap/Row";
-    import Histogram from "./Histogram";
-    import LoadRestrictionsDatesTask from "../tasks/LoadRestrictionsDatesTask.js";
-    import DatePicker from "react-date-picker";
-    import Loading from "./Loading";
-    import LoadTotalCasesTask from "../tasks/LoadTotalCasesTask.js";
-    import "./InfoPanel.css";
+import React from "react";
+import Card from "react-bootstrap/Card";
+import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
+import Row from "react-bootstrap/Row";
+import Histogram from "./Histogram";
+import LoadRestrictionsDatesTask from "../tasks/LoadRestrictionsDatesTask.js";
+import DatePicker from "react-date-picker";
+import Loading from "./Loading";
+import LoadTotalCasesTask from "../tasks/LoadTotalCasesTask.js";
+import "./InfoPanel.css";
 
-    export default class InfoPanel extends React.Component {
-      constructor(props) {
-        super(props);
+export default class InfoPanel extends React.Component {
+  constructor(props) {
+    super(props);
 
-        this.state = {
-          first_restrictions_date: null,
-          lockdown_date: null,
-          counterfactual_first_restrictions_date: null,
-          counterfactual_lockdown_date: null,
-          initial_date: null,
-          maximum_date: null,
-          updateHistogram: false,
-          total_real_cases: null,
-          total_counterfactual_cases: null,
-          dates_changed: false
+    this.state = {
+      first_restrictions_date: null,
+      lockdown_date: null,
+      counterfactual_first_restrictions_date: null,
+      counterfactual_lockdown_date: null,
+      initial_date: null,
+      maximum_date: null,
+      updateHistogram: false,
+      total_real_cases: null,
+      total_counterfactual_cases: null,
+      dates_changed: false,
+    };
 
-        };
+    // Bind the datepicker change functions to allow it to be used by other objects
+    this.onFirstRestrictionsChange = this.onFirstRestrictionsChange.bind(this);
+    this.onLockdownChange = this.onLockdownChange.bind(this);
+  }
 
-        // Bind the datepicker change functions to allow it to be used by other objects
-        this.onFirstRestrictionsChange = this.onFirstRestrictionsChange.bind(this);
-        this.onLockdownChange = this.onLockdownChange.bind(this);
-      }
+  async loadTotalCases(
+    do_real_cases,
+    first_restrictions_date = null,
+    lockdown_date = null
+  ) {
+    const task = new LoadTotalCasesTask();
+    // if there is not an available start or end date in the data use this default ones
+    const initial_date =
+      this.state.initial_date != null ? this.state.initial_date : "2020-02-20";
+    const maximum_date =
+      this.state.maximum_date != null ? this.state.maximum_date : "2020-07-06";
 
-      async loadTotalCases(do_real_cases, first_restrictions_date = null, lockdown_date= null){
+    // reload total real cases only if necesary
+    if (do_real_cases == true) {
+      let [realCases] = await Promise.all([
+        task.getIntegratedCasesCountryData(this.props.isoCode, maximum_date),
+      ]);
 
-        const task = new LoadTotalCasesTask();
-        // if there is not an available start or end date in the data use this default ones
-        const initial_date =
-          this.state.initial_date != null ? this.state.initial_date : "2020-02-20";
-        const maximum_date =
-          this.state.maximum_date != null ? this.state.maximum_date : "2020-07-06";
-
-         // reload total real cases only if necesary
-         if (do_real_cases == true){
-         let [realCases] = await Promise.all([
-          task.getIntegratedCasesCountryData(this.props.isoCode,maximum_date),
-        ]);
-
-        if (( realCases != null) ) {
-           try{
-            this.setState({
-              total_real_cases: realCases.summed_avg_cases_per_million,
-         });
-
-        }catch (error) {
+      if (realCases != null) {
+        try {
+          this.setState({
+            total_real_cases: realCases.summed_avg_cases_per_million,
+          });
+        } catch (error) {
           console.log(error);
         }
-        }
-
       }
+    }
 
+    // converting DateFields that come from the DatePicker to string. If there is no
+    // counterfactual date use the default historical one
 
-        // converting DateFields that come from the DatePicker to string. If there is no
-        // counterfactual date use the default historical one
+    let counterfactual_first_restrictions_date;
 
-        let counterfactual_first_restrictions_date;
+    if (first_restrictions_date == null) {
+      counterfactual_first_restrictions_date = convert(
+        this.state.counterfactual_first_restrictions_date
+      );
+    } else {
+      counterfactual_first_restrictions_date = convert(first_restrictions_date);
+    }
 
-        if (first_restrictions_date == null){
-            counterfactual_first_restrictions_date = convert(this.state.counterfactual_first_restrictions_date)
-        }
-        else{
-             counterfactual_first_restrictions_date = convert(first_restrictions_date)
-        }
+    let counterfactual_lockdown_date;
 
-         let counterfactual_lockdown_date;
+    if (lockdown_date == null) {
+      counterfactual_lockdown_date = convert(
+        this.state.counterfactual_lockdown_date
+      );
+    } else {
+      counterfactual_lockdown_date = convert(lockdown_date);
+    }
 
-         if (lockdown_date == null){
-            counterfactual_lockdown_date = convert(this.state.counterfactual_lockdown_date)
-        }
-        else{
-             counterfactual_lockdown_date = convert(lockdown_date)
-        }
+    let [conterfactualCases] = await Promise.all([
+      task.getIntegratedCounterfactualCountryData(
+        this.props.isoCode,
+        initial_date,
+        maximum_date,
+        counterfactual_first_restrictions_date,
+        counterfactual_lockdown_date
+      ),
+    ]);
 
-
-         let [conterfactualCases] = await Promise.all([
-          task.getIntegratedCounterfactualCountryData(
-            this.props.isoCode,
-            initial_date,
-            maximum_date,
-            counterfactual_first_restrictions_date,
-            counterfactual_lockdown_date
-           ),
-        ]);
-
-
-         if (( conterfactualCases != null)) {
-            try{
-            this.setState({ total_counterfactual_cases: conterfactualCases.summed_avg_cases_per_million });
-         }
-         catch (error) {
-          console.log(error);
-         }
-         }
-
+    if (conterfactualCases != null) {
+      try {
+        this.setState({
+          total_counterfactual_cases:
+            conterfactualCases.summed_avg_cases_per_million,
+        });
+      } catch (error) {
+        console.log(error);
       }
+    }
+  }
 
-      async loadRestrictionData() {
-        // Retrieve Restriction data
-        const task = new LoadRestrictionsDatesTask();
-        let [restrictionsDates] = await Promise.all([
-          task.getCountryRestrictionDates(this.props.isoCode),
-        ]);
+  async loadRestrictionData() {
+    // Retrieve Restriction data
+    const task = new LoadRestrictionsDatesTask();
+    let [restrictionsDates] = await Promise.all([
+      task.getCountryRestrictionDates(this.props.isoCode),
+    ]);
 
-        if ((restrictionsDates != null) & (this.props.isoCode != null)) {
-          try {
-            // Set the component state with the restriction data
-            this.setState({
-              first_restrictions_date: restrictionsDates.first_restrictions_date,
-            });
-            this.setState({ lockdown_date: restrictionsDates.lockdown_date });
-            this.setState({ initial_date: restrictionsDates.initial_date });
-            this.setState({ maximum_date: restrictionsDates.maximum_date });
+    if ((restrictionsDates != null) & (this.props.isoCode != null)) {
+      try {
+        // Set the component state with the restriction data
+        this.setState({
+          first_restrictions_date: restrictionsDates.first_restrictions_date,
+        });
+        this.setState({ lockdown_date: restrictionsDates.lockdown_date });
+        this.setState({ initial_date: restrictionsDates.initial_date });
+        this.setState({ maximum_date: restrictionsDates.maximum_date });
 
-            // we only update counterfactual if we change countries
-            // set them to their actual restriction dates
+        // we only update counterfactual if we change countries
+        // set them to their actual restriction dates
 
-            if (this.state.first_restrictions_date != null) {
-              // for the datepicker to work this needs to be a Date object.
-              this.setState({
-                counterfactual_first_restrictions_date: new Date(
-                  this.state.first_restrictions_date
-                ),
-              });
-            }
-            if (this.state.lockdown_date != null) {
-              // for the datepicker to work this needs to be a Date object.
-              this.setState({
-                counterfactual_lockdown_date: new Date(this.state.lockdown_date),
-              });
-            }
-
-            // set flag updateHistogram to true in order to render the histogram
-            this.setState({ updateHistogram: true });
-          } catch (error) {
-            console.log(error);
-          }
+        if (this.state.first_restrictions_date != null) {
+          // for the datepicker to work this needs to be a Date object.
+          this.setState({
+            counterfactual_first_restrictions_date: new Date(
+              this.state.first_restrictions_date
+            ),
+          });
         }
-      }
-
-      // this runs when the info panel is first mounted
-      async componentDidMount() {
-
-        await this.loadRestrictionData();
-        await this.loadTotalCases(true);
-
-      }
-
-      // this runs when we click in a new country, reload all date information
-      async componentDidUpdate(prevProps) {
-        if (this.props.isoCode !== prevProps.isoCode) {
-          this.setState({ first_restrictions_date: null });
-          this.setState({ lockdown_date: null });
-          this.setState({ initial_date: null });
-          this.setState({ maximum_date: null });
-          this.setState({ counterfactual_first_restrictions_date: null });
-          this.setState({ counterfactual_lockdown_date: null });
-          this.setState({ updateHistogram: false });
-          this.setState({ total_real_cases: false });
-          this.setState({ total_counterfactual_cases: false });
-          this.setState({ dates_changed: false });
-
-
-          await this.loadRestrictionData();
-          await this.loadTotalCases(true);
-
+        if (this.state.lockdown_date != null) {
+          // for the datepicker to work this needs to be a Date object.
+          this.setState({
+            counterfactual_lockdown_date: new Date(this.state.lockdown_date),
+          });
         }
 
-      }
-
-      // this runs when we change the first restrictions counterfactual date
-      async onFirstRestrictionsChange(new_date) {
-        // set updateHistogram to false to clean the histogram component
-        this.setState({ updateHistogram: false });
-        this.setState({ counterfactual_first_restrictions_date: new_date });
-
-        // set updateHistogram to true to render the new histogram component
-        // (comment from Camila: this is a bit hacky and could be improved?)
+        // set flag updateHistogram to true in order to render the histogram
         this.setState({ updateHistogram: true });
-
-        await this.loadTotalCases(false, new_date, this.state.counterfactual_lockdown_date)
-
-        this.setState({ dates_changed: true });
-
-
+      } catch (error) {
+        console.log(error);
       }
+    }
+  }
 
-      // this runs when we change the lockdown counterfactual date
-       async onLockdownChange(new_date) {
-        // set updateHistogram to false to clean the histogram component
-        this.setState({ updateHistogram: false });
-        this.setState({ counterfactual_lockdown_date: new_date });
-        // set updateHistogram to true to render the new histogram component
-        this.setState({ updateHistogram: true });
+  // this runs when the info panel is first mounted
+  async componentDidMount() {
+    await this.loadRestrictionData();
+    await this.loadTotalCases(true);
+  }
 
-        await this.loadTotalCases(false, this.state.counterfactual_first_restrictions_date, new_date)
+  // this runs when we click in a new country, reload all date information
+  async componentDidUpdate(prevProps) {
+    if (this.props.isoCode !== prevProps.isoCode) {
+      this.setState({ first_restrictions_date: null });
+      this.setState({ lockdown_date: null });
+      this.setState({ initial_date: null });
+      this.setState({ maximum_date: null });
+      this.setState({ counterfactual_first_restrictions_date: null });
+      this.setState({ counterfactual_lockdown_date: null });
+      this.setState({ updateHistogram: false });
+      this.setState({ total_real_cases: false });
+      this.setState({ total_counterfactual_cases: false });
+      this.setState({ dates_changed: false });
 
-        this.setState({ dates_changed: true });
+      await this.loadRestrictionData();
+      await this.loadTotalCases(true);
+    }
+  }
 
-      }
+  // this runs when we change the first restrictions counterfactual date
+  async onFirstRestrictionsChange(new_date) {
+    // set updateHistogram to false to clean the histogram component
+    this.setState({ updateHistogram: false });
+    this.setState({ counterfactual_first_restrictions_date: new_date });
 
-      render() {
-        return (
-          <div>
-            {!this.props.isoCode ? null : (
-              <Container fluid>
-                <Row>
-                  <Col xs={3} md={3} lg={3}>
-                    <Row xs={1} md={1} lg={1}>
-                      <Card
-                        style={{
-                          marginTop: "1%",
-                          marginBottom: "1%",
-                        }}
-                        bg={"light"}
-                      >
-                        <Card.Body>
-                          <Card.Title>{`${this.props.countryName}`}</Card.Title>
-                          <Card.Text>First case confimed: XXXX</Card.Text>
-                          <Card.Text>
-                            {" "}
-                            First social distance restrictions:{" "}
-                            {`${this.state.first_restrictions_date}`}.
-                          </Card.Text>
+    // set updateHistogram to true to render the new histogram component
+    // (comment from Camila: this is a bit hacky and could be improved?)
+    this.setState({ updateHistogram: true });
 
-                          {!this.state.lockdown_date ? null : (
-                            <Card.Text>
-                              National lockdown: {` ${this.state.lockdown_date}`}.
-                            </Card.Text>
-                          )}
-                          <Card.Text>
-                            The first wave ended:
-                            {` ${this.state.maximum_date}`}.
-                          </Card.Text>
-                        </Card.Body>
-                      </Card>
-                    </Row>
-                    <Row xs={1} md={1} lg={1}>
-                      <Card
-                        style={{
-                          marginTop: "1%",
-                          marginBottom: "1%",
-                        }}
-                        bg={"light"}
-                      >
-                        <Card.Body>
-                          <Card.Title>Statistics</Card.Title>
-                           {!this.state.total_real_cases ? null : (
-                          <Card.Text>
-                            {`Total COVID-19 Cases per Million: ${this.state.total_real_cases
-                              .toFixed(0)
-                              .toString()} \n `}
-                          </Card.Text>
-                           )}
-                          <Card.Text>{`Total COVID-19 Deaths per Million: XXX`}</Card.Text>
-                          <Card.Text>{`Population density: XXX`}</Card.Text>
-                        </Card.Body>
-                      </Card>
-                    </Row>
-                  </Col>
-                  <Col xs={6} md={6} lg={6}>
-                    <Row xs={1} md={1} lg={1}>
-                      <Row
-                        style={{
-                          display: "flex",
-                          justifyContent: "center",
-                          alignItems: "center",
-                        }}
-                      >
-                        <Col>
-                          <DatePicker
-                            onChange={this.onFirstRestrictionsChange}
-                            value={
-                              this.state.counterfactual_first_restrictions_date
-                            }
-                            format="dd/MM/yyyy"
-                            popperPlacement="bottom-end"
-                            className="form-control"
-                            monthsShown={1}
-                            popperPlacement="bottom"
-                          />
-                        </Col>
-                        <Col>
-                          <DatePicker
-                            onChange={this.onLockdownChange}
-                            value={this.state.counterfactual_lockdown_date}
-                            format="dd/MM/yyyy"
-                            className="form-control"
-                            monthsShown={1}
-                            popperPlacement="bottom"
-                          />
-                        </Col>
-                      </Row>
-                    </Row>
-                    {this.state.updateHistogram === false ? (
-                      <Loading />
-                    ) : (
-                      <Row xs={1} md={1} lg={1}>
-                        <Histogram
-                          isoCode={this.props.isoCode}
-                          height={this.props.height}
-                          initial_date={this.state.initial_date}
-                          maximum_date={this.state.maximum_date}
-                          first_restrictions_date={
-                            this.state.first_restrictions_date
-                          }
-                          lockdown_date={this.state.lockdown_date}
-                          counterfactual_first_restrictions_date={
-                            this.state.counterfactual_first_restrictions_date
-                          }
-                          counterfactual_lockdown_date={
-                            this.state.counterfactual_lockdown_date
-                          }
-                        />
-                      </Row>
-                    )}
-                  </Col>
-                  <Col xs={3} md={3} lg={3}>
-                    <Row xs={1} md={1} lg={1}>
-                      <Card
-                        style={{
-                          marginTop: "1%",
-                          marginBottom: "1%",
-                        }}
-                        bg={"light"}
-                      >
-                        <Card.Body>
-                          <Card.Title>Counterfactual story</Card.Title>
-                          <Card.Text>
-                            Use the calendars to select counterfactual dates for
-                            first social distance restrictions (left) and/or
-                            lockdown (right).
-                          </Card.Text>
-                          <Card.Text> Shift first restrictions: XXX </Card.Text>
-                          <Card.Text> Shift lockdown: XXX </Card.Text>
-                          <Card.Text>
-                            The counterfactual growth is simulated between{" "}
-                            {`${this.state.initial_date}`} and{" "}
-                            {`${this.state.maximum_date}`}.{" "}
-                          </Card.Text>
-                        </Card.Body>
-                      </Card>
-                    </Row>
-                    <Row xs={1} md={1} lg={1}>
-                      <Card
-                        style={{
-                          marginTop: "1%",
-                          marginBottom: "1%",
-                        }}
-                        bg={"light"}
-                      >
-                        <Card.Body>
-                          <Card.Title>Counterfactual Statistics</Card.Title>
-                          {!this.state.total_counterfactual_cases ? null : (
-                          <Card.Text>
-                            {`Total COVID-19 Cases per Million: ${this.state.total_counterfactual_cases
-                              .toFixed(0)
-                             .toString()} \n `}
-                          </Card.Text>
-                            )}
-                           {this.state.dates_changed== false ? null : (
-                          <Card.Text>{`Reduction in total cases: ${((1-this.state.total_counterfactual_cases/this.state.total_real_cases)*100)
-                              .toFixed(1)
-                             .toString()} %\n `}
-                           </Card.Text>
-                          )}
-                        </Card.Body>
-                      </Card>
-                    </Row>
-                  </Col>
+    await this.loadTotalCases(
+      false,
+      new_date,
+      this.state.counterfactual_lockdown_date
+    );
+
+    this.setState({ dates_changed: true });
+  }
+
+  // this runs when we change the lockdown counterfactual date
+  async onLockdownChange(new_date) {
+    // set updateHistogram to false to clean the histogram component
+    this.setState({ updateHistogram: false });
+    this.setState({ counterfactual_lockdown_date: new_date });
+    // set updateHistogram to true to render the new histogram component
+    this.setState({ updateHistogram: true });
+
+    await this.loadTotalCases(
+      false,
+      this.state.counterfactual_first_restrictions_date,
+      new_date
+    );
+
+    this.setState({ dates_changed: true });
+  }
+
+  render() {
+    return (
+      <div>
+        {!this.props.isoCode ? null : (
+          <Container fluid>
+            <Row>
+              <Col xs={3} md={3} lg={3}>
+                <Row xs={1} md={1} lg={1}>
+                  <Card
+                    style={{
+                      marginTop: "1%",
+                      marginBottom: "1%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>{`${this.props.countryName}`}</Card.Title>
+                      <Card.Text>First case confimed: XXXX</Card.Text>
+                      <Card.Text>
+                        {" "}
+                        First social distance restrictions:{" "}
+                        {`${this.state.first_restrictions_date}`}.
+                      </Card.Text>
+
+                      {!this.state.lockdown_date ? null : (
+                        <Card.Text>
+                          National lockdown: {` ${this.state.lockdown_date}`}.
+                        </Card.Text>
+                      )}
+                      <Card.Text>
+                        The first wave ended:
+                        {` ${this.state.maximum_date}`}.
+                      </Card.Text>
+                    </Card.Body>
+                  </Card>
                 </Row>
-              </Container>
-            )}
-          </div>
-        );
-      }
-    }
+                <Row xs={1} md={1} lg={1}>
+                  <Card
+                    style={{
+                      marginTop: "1%",
+                      marginBottom: "1%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>Statistics</Card.Title>
+                      {!this.state.total_real_cases ? null : (
+                        <Card.Text>
+                          {`Total COVID-19 Cases per Million: ${this.state.total_real_cases
+                            .toFixed(0)
+                            .toString()} \n `}
+                        </Card.Text>
+                      )}
+                      <Card.Text>{`Total COVID-19 Deaths per Million: XXX`}</Card.Text>
+                      <Card.Text>{`Population density: XXX`}</Card.Text>
+                    </Card.Body>
+                  </Card>
+                </Row>
+              </Col>
+              <Col xs={6} md={6} lg={6}>
+                <Row xs={1} md={1} lg={1}>
+                  <Row
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      alignItems: "center",
+                    }}
+                  >
+                    <Col>
+                      <DatePicker
+                        onChange={this.onFirstRestrictionsChange}
+                        value={
+                          this.state.counterfactual_first_restrictions_date
+                        }
+                        format="dd/MM/yyyy"
+                        popperPlacement="bottom-end"
+                        className="form-control"
+                        monthsShown={1}
+                        popperPlacement="bottom"
+                      />
+                    </Col>
+                    <Col>
+                      <DatePicker
+                        onChange={this.onLockdownChange}
+                        value={this.state.counterfactual_lockdown_date}
+                        format="dd/MM/yyyy"
+                        className="form-control"
+                        monthsShown={1}
+                        popperPlacement="bottom"
+                      />
+                    </Col>
+                  </Row>
+                </Row>
+                {this.state.updateHistogram === false ? (
+                  <Loading />
+                ) : (
+                  <Row xs={1} md={1} lg={1}>
+                    <Histogram
+                      isoCode={this.props.isoCode}
+                      height={this.props.height}
+                      initial_date={this.state.initial_date}
+                      maximum_date={this.state.maximum_date}
+                      first_restrictions_date={
+                        this.state.first_restrictions_date
+                      }
+                      lockdown_date={this.state.lockdown_date}
+                      counterfactual_first_restrictions_date={
+                        this.state.counterfactual_first_restrictions_date
+                      }
+                      counterfactual_lockdown_date={
+                        this.state.counterfactual_lockdown_date
+                      }
+                    />
+                  </Row>
+                )}
+              </Col>
+              <Col xs={3} md={3} lg={3}>
+                <Row xs={1} md={1} lg={1}>
+                  <Card
+                    style={{
+                      marginTop: "1%",
+                      marginBottom: "1%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>Counterfactual story</Card.Title>
+                      <Card.Text>
+                        Use the calendars to select counterfactual dates for
+                        first social distance restrictions (left) and/or
+                        lockdown (right).
+                      </Card.Text>
+                      <Card.Text> Shift first restrictions: XXX </Card.Text>
+                      <Card.Text> Shift lockdown: XXX </Card.Text>
+                      <Card.Text>
+                        The counterfactual growth is simulated between{" "}
+                        {`${this.state.initial_date}`} and{" "}
+                        {`${this.state.maximum_date}`}.{" "}
+                      </Card.Text>
+                    </Card.Body>
+                  </Card>
+                </Row>
+                <Row xs={1} md={1} lg={1}>
+                  <Card
+                    style={{
+                      marginTop: "1%",
+                      marginBottom: "1%",
+                    }}
+                    bg={"light"}
+                  >
+                    <Card.Body>
+                      <Card.Title>Counterfactual Statistics</Card.Title>
+                      {!this.state.total_counterfactual_cases ? null : (
+                        <Card.Text>
+                          {`Total COVID-19 Cases per Million: ${this.state.total_counterfactual_cases
+                            .toFixed(0)
+                            .toString()} \n `}
+                        </Card.Text>
+                      )}
+                      {this.state.dates_changed == false ? null : (
+                        <Card.Text>
+                          {`Reduction in total cases: ${(
+                            (1 -
+                              this.state.total_counterfactual_cases /
+                                this.state.total_real_cases) *
+                            100
+                          )
+                            .toFixed(1)
+                            .toString()} %\n `}
+                        </Card.Text>
+                      )}
+                    </Card.Body>
+                  </Card>
+                </Row>
+              </Col>
+            </Row>
+          </Container>
+        )}
+      </div>
+    );
+  }
+}
 
-    function convert(inputdate) {
-      var date = inputdate,
-        mnth = ("0" + (inputdate.getMonth() + 1)).slice(-2),
-        day = ("0" + inputdate.getDate()).slice(-2);
-      return [date.getFullYear(), mnth, day].join("-");
-    }
+function convert(inputdate) {
+  var date = inputdate,
+    mnth = ("0" + (inputdate.getMonth() + 1)).slice(-2),
+    day = ("0" + inputdate.getDate()).slice(-2);
+  return [date.getFullYear(), mnth, day].join("-");
+}

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -7,6 +7,7 @@ import Histogram from "./Histogram";
 import LoadRestrictionsDatesTask from "../tasks/LoadRestrictionsDatesTask.js";
 import DatePicker from "react-date-picker";
 import Loading from "./Loading";
+import LoadTotalCasesTask from "../tasks/LoadTotalCasesTask.js";
 import "./InfoPanel.css";
 
 export default class InfoPanel extends React.Component {
@@ -21,6 +22,9 @@ export default class InfoPanel extends React.Component {
       initial_date: null,
       maximum_date: null,
       updateHistogram: false,
+      total_real_cases: null,
+      total_counterfactual_cases: null
+
     };
 
     // Bind the datepicker change functions to allow it to be used by other objects
@@ -74,6 +78,7 @@ export default class InfoPanel extends React.Component {
   // this runs when the info panel is first mounted
   async componentDidMount() {
     await this.loadRestrictionData();
+    await this.loadTotalCases();
   }
 
   // this runs when we click in a new country, reload all date information
@@ -88,6 +93,8 @@ export default class InfoPanel extends React.Component {
       this.setState({ updateHistogram: false });
 
       await this.loadRestrictionData();
+      await this.loadTotalCases();
+
     }
   }
 
@@ -158,11 +165,13 @@ export default class InfoPanel extends React.Component {
                   >
                     <Card.Body>
                       <Card.Title>Statistics</Card.Title>
+                       {!this.state.total_real_cases ? null : (
                       <Card.Text>
-                        {`Total COVID-19 Cases per Million: ${this.props.summedAvgCases
+                        {`Total COVID-19 Cases per Million: ${this.state.total_real_cases
                           .toFixed(0)
                           .toString()} \n `}
                       </Card.Text>
+                       )}
                       <Card.Text>{`Total COVID-19 Deaths per Million: XXX`}</Card.Text>
                       <Card.Text>{`Population density: XXX`}</Card.Text>
                     </Card.Body>
@@ -262,9 +271,13 @@ export default class InfoPanel extends React.Component {
                   >
                     <Card.Body>
                       <Card.Title>Counterfactual Statistics</Card.Title>
+                      {!this.state.total_counterfactual_cases ? null : (
                       <Card.Text>
-                        {`Total COVID-19 Cases per Million:XXX`}
+                        {`Total COVID-19 Cases per Million: ${this.state.total_counterfactual_cases
+                          .toFixed(0)
+                         .toString()} \n `}
                       </Card.Text>
+                        )}
                       <Card.Text>{`% reduction in total cases`}</Card.Text>
                     </Card.Body>
                   </Card>

--- a/frontend/src/components/Utils.js
+++ b/frontend/src/components/Utils.js
@@ -1,0 +1,6 @@
+export default function convert(inputDate) {
+  var date = inputDate,
+    mnth = ("0" + (date.getMonth() + 1)).slice(-2),
+    day = ("0" + date.getDate()).slice(-2);
+  return [date.getFullYear(), mnth, day].join("-");
+}

--- a/frontend/src/tasks/LoadTotalCasesTask.js
+++ b/frontend/src/tasks/LoadTotalCasesTask.js
@@ -4,9 +4,7 @@ import legendItems from "../entities/LegendItems";
 class LoadTotalCasesTask {
   decorateCountries = async (countryGeoms) => {
     try {
-      const integratedCasesData = await this.#getIntegratedCasesData(
-        "2020-07-06"
-      );
+      const integratedCasesData = await this.#getIntegratedCasesData("2020-07-06");
       return this.#processCovidData(countryGeoms, integratedCasesData);
     } catch (error) {
       console.log(error);
@@ -27,11 +25,9 @@ class LoadTotalCasesTask {
     }
   };
 
-  getIntegratedCasesCountryData = async (iso_code, end_date) => {
+  getIntegratedCasesCountryData = async (iso_code,end_date) => {
     try {
-      console.log(
-        `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`
-      );
+
       const res = await axios.get(
         `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`,
         {}
@@ -43,7 +39,7 @@ class LoadTotalCasesTask {
     }
   };
 
-  getIntegratedCounterfactualCountryData = async (
+   getIntegratedCounterfactualCountryData  = async (
     iso_code,
     start_date,
     end_date,
@@ -53,31 +49,38 @@ class LoadTotalCasesTask {
     try {
       // in case there is both restriction and lockdown dates
       if ((lockdown_date != null) & (first_restriction_date != null)) {
+
+
+
         const res_counterfactual_dates = await axios.get(
           `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}&first_restriction_date=${first_restriction_date}&lockdown_date=${lockdown_date}`,
           {}
         );
-        const size = res_counterfactual_dates.data.length;
+
         // return the last date on the model
-        return res_counterfactual_dates.data.last();
+        return res_counterfactual_dates.data[(res_counterfactual_dates.data).length -1];
       } else {
         // some cases there is only first_restriction_date
         if (first_restriction_date != null) {
+
           const res_counterfactual = await axios.get(
             `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}&first_restriction_date=${first_restriction_date}`,
             {}
           );
+
+        // return the last date on the model
+        return res_counterfactual.data[(res_counterfactual.data).length -1];
           // return the last date on the model
-          return res_counterfactual.data.last();
         } else {
+
           const res_counterfactual_default = await axios.get(
             `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`,
+
             {}
           );
 
-          const size = res_counterfactual_default.data.length;
-          // return the last date on the model
-          return res_counterfactual_default.data.last();
+         // return the last date on the model
+          return res_counterfactual_default.data[(res_counterfactual_default.data).length -1];
         }
       }
     } catch (error) {
@@ -85,6 +88,9 @@ class LoadTotalCasesTask {
       return [];
     }
   };
+
+
+
 
   #processCovidData = (countryGeoms, integratedCasesData) => {
     for (let i = 0; i < countryGeoms.length; i++) {

--- a/frontend/src/tasks/LoadTotalCasesTask.js
+++ b/frontend/src/tasks/LoadTotalCasesTask.js
@@ -4,7 +4,7 @@ import legendItems from "../entities/LegendItems";
 class LoadTotalCasesTask {
   decorateCountries = async (countryGeoms) => {
     try {
-      const integratedCasesData = await this.#getIntegratedCasesData();
+      const integratedCasesData = await this.#getIntegratedCasesData("2020-07-06");
       return this.#processCovidData(countryGeoms, integratedCasesData);
     } catch (error) {
       console.log(error);
@@ -12,10 +12,10 @@ class LoadTotalCasesTask {
     }
   };
 
-  #getIntegratedCasesData = async () => {
+  #getIntegratedCasesData = async (end_date) => {
     try {
       const res = await axios.get(
-        "http://localhost:8000/api/cases/real/integrated/?end_date=2020-07-06",
+        `http://localhost:8000/api/cases/real/integrated/?end_date=${end_date}`,
         {}
       );
       return res.data;

--- a/frontend/src/tasks/LoadTotalCasesTask.js
+++ b/frontend/src/tasks/LoadTotalCasesTask.js
@@ -4,7 +4,9 @@ import legendItems from "../entities/LegendItems";
 class LoadTotalCasesTask {
   decorateCountries = async (countryGeoms) => {
     try {
-      const integratedCasesData = await this.#getIntegratedCasesData("2020-07-06");
+      const integratedCasesData = await this.#getIntegratedCasesData(
+        "2020-07-06"
+      );
       return this.#processCovidData(countryGeoms, integratedCasesData);
     } catch (error) {
       console.log(error);
@@ -25,9 +27,11 @@ class LoadTotalCasesTask {
     }
   };
 
-  getIntegratedCasesCountryData = async (iso_code,end_date) => {
+  getIntegratedCasesCountryData = async (iso_code, end_date) => {
     try {
-      console.log(`http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`)
+      console.log(
+        `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`
+      );
       const res = await axios.get(
         `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`,
         {}
@@ -39,7 +43,7 @@ class LoadTotalCasesTask {
     }
   };
 
-   getIntegratedCounterfactualCountryData  = async (
+  getIntegratedCounterfactualCountryData = async (
     iso_code,
     start_date,
     end_date,
@@ -53,7 +57,7 @@ class LoadTotalCasesTask {
           `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}&first_restriction_date=${first_restriction_date}&lockdown_date=${lockdown_date}`,
           {}
         );
-        const size = (res_counterfactual_dates.data).length
+        const size = res_counterfactual_dates.data.length;
         // return the last date on the model
         return res_counterfactual_dates.data.last();
       } else {
@@ -71,8 +75,8 @@ class LoadTotalCasesTask {
             {}
           );
 
-          const size = (res_counterfactual_default.data).length
-         // return the last date on the model
+          const size = res_counterfactual_default.data.length;
+          // return the last date on the model
           return res_counterfactual_default.data.last();
         }
       }
@@ -81,9 +85,6 @@ class LoadTotalCasesTask {
       return [];
     }
   };
-
-
-
 
   #processCovidData = (countryGeoms, integratedCasesData) => {
     for (let i = 0; i < countryGeoms.length; i++) {

--- a/frontend/src/tasks/LoadTotalCasesTask.js
+++ b/frontend/src/tasks/LoadTotalCasesTask.js
@@ -25,6 +25,66 @@ class LoadTotalCasesTask {
     }
   };
 
+  getIntegratedCasesCountryData = async (iso_code,end_date) => {
+    try {
+      console.log(`http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`)
+      const res = await axios.get(
+        `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`,
+        {}
+      );
+      return res.data[0];
+    } catch (error) {
+      console.log(error);
+      return [];
+    }
+  };
+
+   getIntegratedCounterfactualCountryData  = async (
+    iso_code,
+    start_date,
+    end_date,
+    first_restriction_date,
+    lockdown_date
+  ) => {
+    try {
+      // in case there is both restriction and lockdown dates
+      if ((lockdown_date != null) & (first_restriction_date != null)) {
+        const res_counterfactual_dates = await axios.get(
+          `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}&first_restriction_date=${first_restriction_date}&lockdown_date=${lockdown_date}`,
+          {}
+        );
+        const size = (res_counterfactual_dates.data).length
+        // return the last date on the model
+        return res_counterfactual_dates.data.last();
+      } else {
+        // some cases there is only first_restriction_date
+        if (first_restriction_date != null) {
+          const res_counterfactual = await axios.get(
+            `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}&first_restriction_date=${first_restriction_date}`,
+            {}
+          );
+          // return the last date on the model
+          return res_counterfactual.data.last();
+        } else {
+          const res_counterfactual_default = await axios.get(
+            `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`,
+            {}
+          );
+
+          const size = (res_counterfactual_default.data).length
+         // return the last date on the model
+          return res_counterfactual_default.data.last();
+        }
+      }
+    } catch (error) {
+      console.log(error);
+      return [];
+    }
+  };
+
+
+
+
   #processCovidData = (countryGeoms, integratedCasesData) => {
     for (let i = 0; i < countryGeoms.length; i++) {
       // Find matching country

--- a/frontend/src/tasks/LoadTotalCasesTask.js
+++ b/frontend/src/tasks/LoadTotalCasesTask.js
@@ -4,7 +4,9 @@ import legendItems from "../entities/LegendItems";
 class LoadTotalCasesTask {
   decorateCountries = async (countryGeoms) => {
     try {
-      const integratedCasesData = await this.#getIntegratedCasesData("2020-07-06");
+      const integratedCasesData = await this.#getIntegratedCasesData(
+        "2020-07-06"
+      );
       return this.#processCovidData(countryGeoms, integratedCasesData);
     } catch (error) {
       console.log(error);
@@ -25,9 +27,8 @@ class LoadTotalCasesTask {
     }
   };
 
-  getIntegratedCasesCountryData = async (iso_code,end_date) => {
+  getIntegratedCasesCountryData = async (iso_code, end_date) => {
     try {
-
       const res = await axios.get(
         `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`,
         {}
@@ -39,7 +40,7 @@ class LoadTotalCasesTask {
     }
   };
 
-   getIntegratedCounterfactualCountryData  = async (
+  getIntegratedCounterfactualCountryData = async (
     iso_code,
     start_date,
     end_date,
@@ -49,38 +50,37 @@ class LoadTotalCasesTask {
     try {
       // in case there is both restriction and lockdown dates
       if ((lockdown_date != null) & (first_restriction_date != null)) {
-
-
-
         const res_counterfactual_dates = await axios.get(
           `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}&first_restriction_date=${first_restriction_date}&lockdown_date=${lockdown_date}`,
           {}
         );
 
         // return the last date on the model
-        return res_counterfactual_dates.data[(res_counterfactual_dates.data).length -1];
+        return res_counterfactual_dates.data[
+          res_counterfactual_dates.data.length - 1
+        ];
       } else {
         // some cases there is only first_restriction_date
         if (first_restriction_date != null) {
-
           const res_counterfactual = await axios.get(
             `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}&first_restriction_date=${first_restriction_date}`,
             {}
           );
 
-        // return the last date on the model
-        return res_counterfactual.data[(res_counterfactual.data).length -1];
+          // return the last date on the model
+          return res_counterfactual.data[res_counterfactual.data.length - 1];
           // return the last date on the model
         } else {
-
           const res_counterfactual_default = await axios.get(
             `http://localhost:8000/api/cases/counterfactual/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`,
 
             {}
           );
 
-         // return the last date on the model
-          return res_counterfactual_default.data[(res_counterfactual_default.data).length -1];
+          // return the last date on the model
+          return res_counterfactual_default.data[
+            res_counterfactual_default.data.length - 1
+          ];
         }
       }
     } catch (error) {
@@ -88,9 +88,6 @@ class LoadTotalCasesTask {
       return [];
     }
   };
-
-
-
 
   #processCovidData = (countryGeoms, integratedCasesData) => {
     for (let i = 0; i < countryGeoms.length; i++) {


### PR DESCRIPTION
Fixes #85 

- [x] Modify LoadTotalCasesTask.j to get the end date as an input to that function.
- [x] Add extra functions to LoadTotalCasesTask for get real and counterfactual total cases.
- [x] Create a loadtotalcases() function in the infopanel component to load this data. Make sure it gets updated when the restriction dates change.
- [x] Calculate relative change between natural history and Counterfacual
- [x] Update placeholders the Natural history and Counterfacual panel with the new info. 
- [x] Create a new Utils.js file with common function between components.
- [x] Deleted unused MyDatesPicker file that was still being tracked for some reason.