### PR TITLE
Fix integrated counterfactual

### DIFF
--- a/backend/cases/views.py
+++ b/backend/cases/views.py
@@ -60,8 +60,6 @@ class CasesCounterfactualDailyAbsoluteView(
             iso_codes, boundary_dates, knot_dates, summary=False
         )
 
-        # return NotImplementedError
-
 
 class CasesCounterfactualDailyNormalisedView(
     CasesCounterfactualViewMixin, viewsets.ViewSet
@@ -82,9 +80,10 @@ class CasesCounterfactualIntegratedView(CasesCounterfactualViewMixin, viewsets.V
     serializer_class = CasesCounterfactualIntegratedSerializer
 
     def simulate(self, iso_codes, boundary_dates, knot_dates):
-        return CounterfactualCasesRecord.simulate(
+        records = CounterfactualCasesRecord.simulate(
             iso_codes, boundary_dates, knot_dates, summary=True
         )
+        return [max(records, key=lambda r: r["date"])] if records else []
 
 
 class PerCountryRealViewMixin(ABC):

--- a/backend/counterfactual/simulation.py
+++ b/backend/counterfactual/simulation.py
@@ -342,13 +342,17 @@ def simulate_single_country(
         time_period_boundaries = [pd.Timestamp.min, pd.Timestamp.max]
         growth_factors = [knots.growth_factor_0_1]
         with suppress(AttributeError):
-            # If knot_date_1 exists then we know that growth_factor_1_2 exists
-            time_period_boundaries.append(knots.counterfactual_knot_date_1)
-            growth_factors.append(knots.growth_factor_1_2)
+            # Check counterfactual_knot_date_1 for NaT before adding it
+            if not pd.isnull(knots.counterfactual_knot_date_1):
+                # If knot_date_1 exists then we know that growth_factor_1_2 exists
+                time_period_boundaries.append(knots.counterfactual_knot_date_1)
+                growth_factors.append(knots.growth_factor_1_2)
         with suppress(AttributeError):
-            # If knot_date_2 exists then we know that growth_factor_2_3 exists
-            time_period_boundaries.append(knots.counterfactual_knot_date_2)
-            growth_factors.append(knots.growth_factor_2_3)
+            # Check counterfactual_knot_date_2 for NaT before adding it
+            if not pd.isnull(knots.counterfactual_knot_date_2):
+                # If knot_date_2 exists then we know that growth_factor_2_3 exists
+                time_period_boundaries.append(knots.counterfactual_knot_date_2)
+                growth_factors.append(knots.growth_factor_2_3)
         time_period_boundaries = sorted(time_period_boundaries)
 
         # Simulate all days from the second onwards

--- a/backend/dates/serializers.py
+++ b/backend/dates/serializers.py
@@ -1,27 +1,6 @@
 """Serializers for Django dates app"""
 from rest_framework import serializers
-from .models import ModelDateRange, KnotDateSet, PossibleDateSet
-
-
-class KnotDateSetSerializer(serializers.ModelSerializer):
-    """Serializer for KnotDateSetView"""
-
-    iso_code = serializers.PrimaryKeyRelatedField(source="country", read_only=True)
-
-    class Meta:
-        """Metaclass for output fields"""
-
-        model = KnotDateSet
-        fields = (
-            "iso_code",
-            "knot_date_1",
-            "knot_date_2",
-            "n_knots",
-            "growth_factor_0_1",
-            "growth_factor_1_2",
-            "growth_factor_2_3",
-            "weight",
-        )
+from .models import ModelDateRange, PossibleDateSet
 
 
 class ModelDateRangeSerializer(serializers.ModelSerializer):

--- a/backend/dates/views.py
+++ b/backend/dates/views.py
@@ -2,20 +2,11 @@
 from rest_framework import viewsets
 from django.contrib.postgres.aggregates import ArrayAgg
 from .serializers import (
-    KnotDateSetSerializer,
     ModelDateRangeSerializer,
     PossibleLockdownDateSetSerializer,
     PossibleRestrictionsDateSetSerializer,
 )
-from .models import KnotDateSet, ModelDateRange, PossibleDateSet
-
-
-class KnotDateSetView(viewsets.ReadOnlyModelViewSet):
-    """View for KnotDateSet"""
-
-    serializer_class = KnotDateSetSerializer
-    queryset = KnotDateSet.objects.all()  # pylint: disable=no-member
-    http_method_names = ["get", "list"]
+from .models import ModelDateRange, PossibleDateSet
 
 
 class ModelDateRangeView(viewsets.ReadOnlyModelViewSet):

--- a/frontend/src/components/CountryStatistics.jsx
+++ b/frontend/src/components/CountryStatistics.jsx
@@ -7,6 +7,7 @@ import React from "react";
 
 const propTypes = exact({
   isoCode: PropTypes.string.isRequired,
+  dateStart: PropTypes.string.isRequired,
   dateEnd: PropTypes.string.isRequired,
   onDataChange: PropTypes.func.isRequired,
 });
@@ -32,10 +33,12 @@ class CountryStatistics extends React.PureComponent {
     try {
       const realCases = await statistics.loadIntegratedCases(
         this.props.isoCode,
+        this.props.dateStart,
         this.props.dateEnd
       );
       const realDeaths = await statistics.loadIntegratedDeaths(
         this.props.isoCode,
+        this.props.dateStart,
         this.props.dateEnd
       );
       // Update state and pass values back to callback function

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -43,7 +43,7 @@ class Histogram extends React.PureComponent {
     console.log("Loading real and counterfactual cases");
     // Retrieve real and counterfactual data in parallel
     const task = new LoadDailyCasesTask();
-    let [casesCounterfactual, casesReal] = await Promise.all([
+    const [casesCounterfactual, casesReal] = await Promise.all([
       task.getCounterfactualCovidCases(
         this.props.isoCode,
         this.props.dateInitial,
@@ -75,10 +75,6 @@ class Histogram extends React.PureComponent {
       }
       this.setState({ casesData: casesData });
     }
-  }
-
-  async componentDidMount() {
-    await this.loadCasesData();
   }
 
   async componentDidUpdate(prevProps) {

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -190,6 +190,7 @@ class InfoPanel extends React.PureComponent {
                 <Row xs={1} md={1} lg={1}>
                   <CountryStatistics
                     isoCode={this.props.isoCode}
+                    dateStart={this.state.dateModelStart}
                     dateEnd={this.state.dateModelEnd}
                     onDataChange={this.onRealDataChange}
                   />

--- a/frontend/src/tasks/LoadDailyCasesTask.js
+++ b/frontend/src/tasks/LoadDailyCasesTask.js
@@ -1,22 +1,7 @@
 import axios from "axios";
 
 class LoadDailyCasesTask {
-  // function to get real cases for a period of time,
-  #getDailyCovidCases = async (datatype, iso_code, start_date, end_date) => {
-    try {
-      const target = `http://localhost:8000/api/cases/${datatype}/daily/normalised/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`;
-      console.debug(`Backend ${target}`);
-      const response = await axios.get(target, {});
-      return response.data;
-    } catch (error) {
-      console.log(error);
-      return [];
-    }
-  };
-
-  // function to get counterfactual cases for given restriction dates for a period of time
-  #getDailyCounterfactualCovidCases = async (
-    datatype,
+  getCounterfactualCovidCases = async (
     iso_code,
     start_date,
     end_date,
@@ -24,7 +9,7 @@ class LoadDailyCasesTask {
     lockdown_date
   ) => {
     try {
-      var target = `http://localhost:8000/api/cases/${datatype}/daily/normalised/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`;
+      var target = `http://localhost:8000/api/cases/counterfactual/daily/normalised/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`;
       if (first_restriction_date != null) {
         target = `${target}&first_restriction_date=${first_restriction_date}`;
       }
@@ -40,32 +25,16 @@ class LoadDailyCasesTask {
     }
   };
 
-  getCounterfactualCovidCases = async (
-    iso_code,
-    start_date,
-    end_date,
-    first_restriction,
-    lockdown_date
-  ) => {
-    const data = await this.#getDailyCounterfactualCovidCases(
-      "counterfactual",
-      iso_code,
-      start_date,
-      end_date,
-      first_restriction,
-      lockdown_date
-    );
-    return data;
-  };
-
   getRealCovidCases = async (iso_code, start_date, end_date) => {
-    const data = await this.#getDailyCovidCases(
-      "real",
-      iso_code,
-      start_date,
-      end_date
-    );
-    return data;
+    try {
+      const target = `http://localhost:8000/api/cases/real/daily/normalised/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`;
+      console.debug(`Backend ${target}`);
+      const response = await axios.get(target, {});
+      return response.data;
+    } catch (error) {
+      console.log(error);
+      return [];
+    }
   };
 }
 

--- a/frontend/src/tasks/LoadPerCountryStatisticsTask.js
+++ b/frontend/src/tasks/LoadPerCountryStatisticsTask.js
@@ -14,9 +14,9 @@ class LoadPerCountryStatisticsTask {
     }
   };
 
-  loadIntegratedCases = async (iso_code, end_date) => {
+  loadIntegratedCases = async (iso_code, start_date, end_date) => {
     try {
-      const target = `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`;
+      const target = `http://localhost:8000/api/cases/real/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`;
       console.debug(`Backend ${target}`);
       const response = await axios.get(target, {});
       return response.data[0];
@@ -63,9 +63,9 @@ class LoadPerCountryStatisticsTask {
   };
 
   // Asynchronously load integrated deaths data from Django backend
-  loadIntegratedDeaths = async (iso_code, end_date) => {
+  loadIntegratedDeaths = async (iso_code, start_date, end_date) => {
     try {
-      const target = `http://localhost:8000/api/deaths/real/integrated/?iso_code=${iso_code}&end_date=${end_date}`;
+      const target = `http://localhost:8000/api/deaths/real/integrated/?iso_code=${iso_code}&start_date=${start_date}&end_date=${end_date}`;
       console.debug(`Backend ${target}`);
       const response = await axios.get(target, {});
       return response.data[0];

--- a/frontend/src/tasks/LoadPerCountryStatisticsTask.js
+++ b/frontend/src/tasks/LoadPerCountryStatisticsTask.js
@@ -44,11 +44,11 @@ class LoadPerCountryStatisticsTask {
       }
       console.debug(`Backend ${target}`);
       const response = await axios.get(target, {});
-      // Use data from the latest date in the response
+      // Return counterfactual data if there is any
       if (response.data.length) {
-        return response.data[response.data.length - 1];
+        return response.data[0];
       }
-      // Return null values if there is no counterfactual data
+      // ... otherwise warn and return null values
       console.warn(
         `No counterfactual data returned for ${iso_code}. First restriction date ${first_restriction_date}; lockdown date ${lockdown_date}.`
       );


### PR DESCRIPTION
- Removed unused code which exposed the `KnotPoints` model via the API
- Changed `cases/counterfactual/integrated` API to match `cases/real/integrated`
- Minor simplification to `LoadDailyCasesTask` which previously had two functions that passed all their arguments on to two other functions
- Added `start_date` to `loadIntegratedCases` to match `loadIntegratedCounterfactualCases`

Closes #100