### PR TITLE
Responsive dashboard design

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,9 @@
 # CounterfactualCovid19 backend
+
 This project was bootstrapped with [Django start project](https://docs.djangoproject.com/en/3.1/ref/django-admin/#startproject).
 
 ## Prerequisites
+
 You will need to install the following dependencies in order to run this app:
 
 - [PostgreSQL](#postgresql)
@@ -25,7 +27,7 @@ createdb counterfactualcovid
 createuser django -P
 ```
 
-and type the password that is being used for this project (you can find it in line 90 of [this file](/backend/settings/common.py)). 
+and type the password that is being used for this project (you can find it in line 90 of [this file](/backend/settings/common.py)).
 
 You can test that `PostgreSQL` is correctly configured by running
 

--- a/backend/cases/models/ephemeral.py
+++ b/backend/cases/models/ephemeral.py
@@ -18,9 +18,9 @@ class CounterfactualCasesRecord:
     @staticmethod
     def to_date(input_string):
         """Convert a string to a datetime date"""
-        if input_string:
-            return datetime.datetime.strptime(input_string, r"%Y-%m-%d").date()
-        return None
+        if not input_string or input_string == "null":
+            return None
+        return datetime.datetime.strptime(input_string, r"%Y-%m-%d").date()
 
     @staticmethod
     def simulate(iso_codes, boundary_dates, knot_dates, summary):

--- a/frontend/src/components/DateChooser.jsx
+++ b/frontend/src/components/DateChooser.jsx
@@ -87,7 +87,7 @@ class DateChooser extends React.PureComponent {
           isClearable
           {...extraProps}
         />
-        <p className={styles.centered_text}>
+        <p className={styles.caption}>
           <em>{this.props.caption}</em>
         </p>
       </div>

--- a/frontend/src/components/HeaderPanel.jsx
+++ b/frontend/src/components/HeaderPanel.jsx
@@ -67,7 +67,12 @@ class HeaderPanel extends React.PureComponent {
 
     return (
       <Row className={`${styles.full_available_height} g-0`}>
-        <Col xs={3} md={2} xl={1} className={`${styles.contents_centered} row-height`}>
+        <Col
+          xs={3}
+          md={2}
+          xl={1}
+          className={`${styles.contents_centered} row-height`}
+        >
           <Row className={styles.contents_padded_sm}>
             <Image src={logoLeeds} alt="Lida Logo" />
           </Row>
@@ -75,7 +80,12 @@ class HeaderPanel extends React.PureComponent {
             <Image src={logoTuring} alt="Turing Logo" />
           </Row>
         </Col>
-        <Col xs={7} md={9} xl={10} className={`${styles.contents_centered} ${styles.contents_padded_sm} row-height`}>
+        <Col
+          xs={7}
+          md={9}
+          xl={10}
+          className={`${styles.contents_centered} ${styles.contents_padded_sm} row-height`}
+        >
           <Card bg={"light"} text={"dark"}>
             <Card.Body>
               <Card.Title className={styles.responsive_card_title}>
@@ -90,7 +100,12 @@ class HeaderPanel extends React.PureComponent {
             </Card.Body>
           </Card>
         </Col>
-        <Col xs={2} md={1} xl={1} className={`${styles.contents_centered} ${styles.contents_padded_sm} row-height`}>
+        <Col
+          xs={2}
+          md={1}
+          xl={1}
+          className={`${styles.contents_centered} ${styles.contents_padded_sm} row-height`}
+        >
           <OverlayTrigger
             trigger="click"
             placement="bottom"

--- a/frontend/src/components/HeaderPanel.jsx
+++ b/frontend/src/components/HeaderPanel.jsx
@@ -9,14 +9,11 @@ import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Popover from "react-bootstrap/Popover";
 import React from "react";
 import Row from "react-bootstrap/Row";
-import commonStyles from "../css/Common.module.css";
-import localStyles from "../css/HeaderPanel.module.css";
+import styles from "../css/Common.module.css";
 
 const propTypes = exact({});
 
 const defaultProps = {};
-
-const styles = { ...commonStyles, ...localStyles };
 
 class HeaderPanel extends React.PureComponent {
   constructor(props) {
@@ -69,16 +66,16 @@ class HeaderPanel extends React.PureComponent {
     );
 
     return (
-      <Row>
-        <Col xs={3} md={2} xl={1} className={styles.contents_centered}>
-          <Row className={styles.logo}>
+      <Row className={`${styles.full_available_height} g-0`}>
+        <Col xs={3} md={2} xl={1} className={`${styles.contents_centered} row-height`}>
+          <Row className={styles.contents_padded_sm}>
             <Image src={logoLeeds} alt="Lida Logo" />
           </Row>
-          <Row className={styles.logo}>
+          <Row className={styles.contents_padded_sm}>
             <Image src={logoTuring} alt="Turing Logo" />
           </Row>
         </Col>
-        <Col xs={7} md={9} xl={10} className={styles.contents_centered}>
+        <Col xs={7} md={9} xl={10} className={`${styles.contents_centered} ${styles.contents_padded_sm} row-height`}>
           <Card bg={"light"} text={"dark"}>
             <Card.Body>
               <Card.Title className={styles.responsive_card_title}>
@@ -93,7 +90,7 @@ class HeaderPanel extends React.PureComponent {
             </Card.Body>
           </Card>
         </Col>
-        <Col xs={2} md={1} xl={1} className={styles.contents_centered}>
+        <Col xs={2} md={1} xl={1} className={`${styles.contents_centered} ${styles.contents_padded_sm} row-height`}>
           <OverlayTrigger
             trigger="click"
             placement="bottom"

--- a/frontend/src/components/HeaderPanel.jsx
+++ b/frontend/src/components/HeaderPanel.jsx
@@ -70,7 +70,7 @@ class HeaderPanel extends React.PureComponent {
 
     return (
       <Row>
-        <Col xs={1} md={1} lg={1} className={styles.contents_centered}>
+        <Col xs={3} md={2} xl={1} className={styles.contents_centered}>
           <Row className={styles.logo}>
             <Image src={logoLeeds} alt="Lida Logo" />
           </Row>
@@ -78,14 +78,14 @@ class HeaderPanel extends React.PureComponent {
             <Image src={logoTuring} alt="Turing Logo" />
           </Row>
         </Col>
-        <Col xs={10} md={10} lg={10} className={styles.contents_centered}>
+        <Col xs={7} md={9} xl={10} className={styles.contents_centered}>
           <Card bg={"light"} text={"dark"}>
             <Card.Body>
-              <Card.Title>
+              <Card.Title className={styles.responsive_card_title}>
                 What if?: The counterfactual story of the first wave of COVID-19
                 in Europe.
               </Card.Title>
-              <Card.Text>
+              <Card.Text className={styles.responsive_card_text}>
                 This dashboard contains data and counterfactual simulations of
                 the growth of COVID-19 cases during Europe's first wave. Click
                 on a country to start.
@@ -93,7 +93,7 @@ class HeaderPanel extends React.PureComponent {
             </Card.Body>
           </Card>
         </Col>
-        <Col xs={1} md={1} lg={1} className={styles.contents_centered}>
+        <Col xs={2} md={1} xl={1} className={styles.contents_centered}>
           <OverlayTrigger
             trigger="click"
             placement="bottom"

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -105,14 +105,17 @@ class Histogram extends React.PureComponent {
     if (this.state.casesData.length === 0) {
       return <Loading />;
     }
+    // Set the x-axis and y-axis offsets based on the current window size
+    const axisOffsetHorizontal = 0.03 * window.innerWidth;
+    const axisOffsetVertical = 0.03 * window.innerHeight;
     return (
-      <ResponsiveContainer width="100%">
+      <ResponsiveContainer width="100%" aspect={2}>
         <ComposedChart data={this.state.casesData}>
           <CartesianGrid stroke="#f5f5f5" />
-          <XAxis dataKey="date" />
-          <YAxis />
+          <XAxis dataKey="date" height={axisOffsetVertical} />
+          <YAxis width={axisOffsetHorizontal}/>
           <Tooltip />
-          <Legend />
+          <Legend align="center"/>
           <Bar dataKey="Real cases" fill="#413ea0" />
           <Line
             type="monotone"

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -76,7 +76,8 @@ class Histogram extends React.PureComponent {
         const record = {
           date: casesReal[i].date,
           "Real cases": casesReal[i].summed_avg_cases_per_million,
-          "Counterfactual cases": counterfactual.summed_avg_cases_per_million || 0,
+          "Counterfactual cases":
+            counterfactual.summed_avg_cases_per_million || 0,
         };
         casesData.push(record);
       }
@@ -121,9 +122,9 @@ class Histogram extends React.PureComponent {
         <ComposedChart data={this.state.casesData}>
           <CartesianGrid stroke="#f5f5f5" />
           <XAxis dataKey="date" height={axisOffsetVertical} />
-          <YAxis width={axisOffsetHorizontal}/>
+          <YAxis width={axisOffsetHorizontal} />
           <Tooltip />
-          <Legend align="center"/>
+          <Legend align="center" />
           <Bar dataKey="Real cases" fill="#413ea0" />
           <Line
             type="monotone"

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -10,12 +10,15 @@ import {
   YAxis,
   ReferenceLine,
 } from "recharts";
+import Col from "react-bootstrap/Col";
 import exact from "prop-types-exact";
 import LoadDailyCasesTask from "../tasks/LoadDailyCasesTask";
 import Loading from "./Loading";
 import pDebounce from "p-debounce";
 import PropTypes from "prop-types";
 import React from "react";
+import commonStyles from "../css/Common.module.css";
+import localStyles from "../css/Histogram.module.css";
 
 const propTypes = exact({
   dateFinal: PropTypes.string,
@@ -28,6 +31,8 @@ const propTypes = exact({
 });
 
 const defaultProps = {};
+
+const styles = { ...commonStyles, ...localStyles };
 
 class Histogram extends React.PureComponent {
   constructor(props) {
@@ -71,8 +76,7 @@ class Histogram extends React.PureComponent {
         const record = {
           date: casesReal[i].date,
           "Real cases": casesReal[i].summed_avg_cases_per_million,
-          "Counterfactual cases":
-            counterfactual.summed_avg_cases_per_million || 0,
+          "Counterfactual cases": counterfactual.summed_avg_cases_per_million || 0,
         };
         casesData.push(record);
       }
@@ -101,11 +105,15 @@ class Histogram extends React.PureComponent {
   }
 
   render() {
-    console.debug("Redrawing histogram...");
     if (this.state.casesData.length === 0) {
-      return <Loading />;
+      return (
+        <Col xs={12} className={styles.loading}>
+          <Loading />
+        </Col>
+      );
     }
     // Set the x-axis and y-axis offsets based on the current window size
+    console.debug("Redrawing histogram...");
     const axisOffsetHorizontal = 0.03 * window.innerWidth;
     const axisOffsetVertical = 0.03 * window.innerHeight;
     return (

--- a/frontend/src/components/Histogram.jsx
+++ b/frontend/src/components/Histogram.jsx
@@ -106,7 +106,7 @@ class Histogram extends React.PureComponent {
       return <Loading />;
     }
     return (
-      <ResponsiveContainer>
+      <ResponsiveContainer width="100%">
         <ComposedChart data={this.state.casesData}>
           <CartesianGrid stroke="#f5f5f5" />
           <XAxis dataKey="date" />

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -186,7 +186,7 @@ class InfoPanel extends React.PureComponent {
         {!this.props.isoCode ? null : (
           <Container fluid>
             <Row>
-              <Col xs={3} className={styles.contents_spaced}>
+              <Col xs={3} className={styles.space_child_rows}>
                 <Row xs={1} className={styles.full_available_width}>
                   <CountryDates
                     countryName={this.state.countryName}
@@ -208,7 +208,7 @@ class InfoPanel extends React.PureComponent {
                 <Row
                   key={this.props.isoCode} /* Recreate whenever key changes */
                   style={{ height: dateChooserHeight }}
-                  className={`${styles.full_available_width} ${styles.contents_spaced} ${styles.spacing_vertical}`}
+                  className={`${styles.full_available_width} ${styles.space_child_columns} ${styles.spacing_vertical}`}
                 >
                   <Col xs={6}>
                     <DateChooser
@@ -248,7 +248,7 @@ class InfoPanel extends React.PureComponent {
                   />
                 </Row>
               </Col>
-              <Col xs={3} className={styles.contents_spaced}>
+              <Col xs={3} className={styles.space_child_rows}>
                 <Row xs={1} className={styles.full_available_width}>
                   <CounterfactualStory
                     dateStart={this.state.dateModelStart}

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -177,105 +177,89 @@ class InfoPanel extends React.PureComponent {
   }
 
   render() {
-    // Set explicit heights taking the 2vh margin into account
-    const availableHeight = Number(this.props.height.replace("vh", ""));
-    const dateChooserHeight = `${0.2 * availableHeight - 2}vh`;
-    const histogramHeight = `${0.8 * availableHeight - 2}vh`;
+    // If there is country selected then return an empty <div>
+    if (this.props.isoCode == null) {
+      return <div></div>
+    }
+    // Otherwise return the InfoPanel container
     return (
-      <div>
-        {!this.props.isoCode ? null : (
-          <Container fluid>
-            <Row>
-              <Col xs={3} className={styles.space_child_rows}>
-                <Row xs={1} className={styles.full_available_width}>
-                  <CountryDates
-                    countryName={this.state.countryName}
-                    dateFirstWaveEnd={this.state.dateFirstCase}
-                    dateFirstWaveStart={this.state.dateModelEnd}
-                    dateFirstRestrictions={this.state.dateFirstRestrictionsReal}
-                    dateLockdown={this.state.dateLockdownReal}
-                  />
-                </Row>
-                <Row xs={1} className={styles.full_available_width}>
-                  <CountryStatistics
-                    totalCases={this.state.totalCasesReal}
-                    totalDeaths={this.state.totalDeathsReal}
-                    populationDensity={this.state.populationDensity}
-                  />
-                </Row>
+      <Container fluid>
+        <Row className={`${styles.full_available_height} g-0`}>
+          <Col xs={3} md={2} lg={3} className={"row-height"}>
+            <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
+              <CountryDates
+                countryName={this.state.countryName}
+                dateFirstWaveEnd={this.state.dateFirstCase}
+                dateFirstWaveStart={this.state.dateModelEnd}
+                dateFirstRestrictions={this.state.dateFirstRestrictionsReal}
+                dateLockdown={this.state.dateLockdownReal}
+              />
+            </Row>
+            <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
+              <CountryStatistics
+                totalCases={this.state.totalCasesReal}
+                totalDeaths={this.state.totalDeathsReal}
+                populationDensity={this.state.populationDensity}
+              />
+            </Row>
+          </Col>
+          <Col xs={6} md={8} lg={6} className={"row-height"}>
+            <Row xs={1} className="g-0"
+             key={this.props.isoCode} /* Recreate whenever key changes */
+            >
+              <Col xs={6}>
+                <DateChooser
+                  allowedDates={this.state.allowedDatesFirstRestrictions}
+                  caption="Social distancing"
+                  nominalDate={this.state.dateFirstRestrictionsReal}
+                  onDateChange={this.onFirstRestrictionsChange}
+                />
               </Col>
               <Col xs={6}>
-                <Row
-                  key={this.props.isoCode} /* Recreate whenever key changes */
-                  style={{ height: dateChooserHeight }}
-                  className={`${styles.full_available_width} ${styles.space_child_columns} ${styles.spacing_vertical}`}
-                >
-                  <Col xs={6}>
-                    <DateChooser
-                      allowedDates={this.state.allowedDatesFirstRestrictions}
-                      caption="Social distancing"
-                      nominalDate={this.state.dateFirstRestrictionsReal}
-                      onDateChange={this.onFirstRestrictionsChange}
-                    />
-                  </Col>
-                  <Col xs={6}>
-                    <DateChooser
-                      allowedDates={this.state.allowedDatesLockdown}
-                      caption="National lockdown"
-                      nominalDate={this.state.dateLockdownReal}
-                      onDateChange={this.onLockdownChange}
-                    />
-                  </Col>
-                </Row>
-                <Row
-                  className={`${styles.full_available_width} ${styles.spacing_vertical}`}
-                  style={{ height: histogramHeight }}
-                >
-                  <Histogram
-                    isoCode={this.props.isoCode}
-                    dateInitial={this.state.dateFirstCase}
-                    dateFinal={this.state.dateModelEnd}
-                    dateFirstRestrictionsReal={
-                      this.state.dateFirstRestrictionsReal
-                    }
-                    dateLockdownReal={this.state.dateLockdownReal}
-                    dateFirstRestrictionsCounterfactual={
-                      this.state.dateFirstRestrictionsCounterfactual
-                    }
-                    dateLockdownCounterfactual={
-                      this.state.dateLockdownCounterfactual
-                    }
-                  />
-                </Row>
-              </Col>
-              <Col xs={3} className={styles.space_child_rows}>
-                <Row xs={1} className={styles.full_available_width}>
-                  <CounterfactualStory
-                    dateStart={this.state.dateModelStart}
-                    dateEnd={this.state.dateModelEnd}
-                  />
-                </Row>
-                <Row xs={1} className={styles.full_available_width}>
-                  <CounterfactualStatistics
-                    totalCasesCounterfactual={
-                      this.state.totalCasesCounterfactual
-                    }
-                    totalCasesReal={this.state.totalCasesReal}
-                    shiftFirstRestrictions={this.daysDelta(
-                      this.state.dateFirstRestrictionsReal,
-                      this.state.dateFirstRestrictionsCounterfactual
-                    )}
-                    shiftLockdown={this.daysDelta(
-                      this.state.dateLockdownReal,
-                      this.state.dateLockdownCounterfactual
-                    )}
-                  />
-                </Row>
+                <DateChooser
+                  allowedDates={this.state.allowedDatesLockdown}
+                  caption="National lockdown"
+                  nominalDate={this.state.dateLockdownReal}
+                  onDateChange={this.onLockdownChange}
+                />
               </Col>
             </Row>
-          </Container>
-        )}
-      </div>
+            <Row xs={1} className="g-0">
+              <Histogram
+                isoCode={this.props.isoCode}
+                dateInitial={this.state.dateFirstCase}
+                dateFinal={this.state.dateModelEnd}
+                dateFirstRestrictionsReal={this.state.dateFirstRestrictionsReal}
+                dateLockdownReal={this.state.dateLockdownReal}
+                dateFirstRestrictionsCounterfactual={this.state.dateFirstRestrictionsCounterfactual}
+                dateLockdownCounterfactual={this.state.dateLockdownCounterfactual}
+              />
+            </Row>
+          </Col>
+          <Col xs={3} md={2} lg={3} className="row-height">
+            <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
+              <CounterfactualStory
+                dateStart={this.state.dateModelStart}
+                dateEnd={this.state.dateModelEnd}
+              />
+            </Row>
+            <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
+              <CounterfactualStatistics
+                totalCasesCounterfactual={this.state.totalCasesCounterfactual}
+                totalCasesReal={this.state.totalCasesReal}
+                shiftFirstRestrictions={this.daysDelta(
+                  this.state.dateFirstRestrictionsReal,
+                  this.state.dateFirstRestrictionsCounterfactual
+                )}
+                shiftLockdown={this.daysDelta(
+                  this.state.dateLockdownReal,
+                  this.state.dateLockdownCounterfactual
+                )}
+              />
+            </Row>
+          </Col>
+        </Row>
+      </Container>
     );
   }
 }

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -184,7 +184,7 @@ class InfoPanel extends React.PureComponent {
     return (
       <Container fluid>
         <Row className={`${styles.full_available_height} g-0`}>
-          <Col xs={3} md={2} lg={3} className="row-height">
+          <Col xs={{span: 6, order: 2}} md={{span: 2, order: 1}} lg={{span: 3, order: 1}} className="row-height">
             <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
               <CountryDates
                 countryName={this.state.countryName}
@@ -202,9 +202,9 @@ class InfoPanel extends React.PureComponent {
               />
             </Row>
           </Col>
-          <Col xs={6} md={8} lg={6} className="row-height">
+          <Col xs={{span: 12, order: 1}} md={{span: 8, order: 2}} lg={{span: 6, order: 2}} className="row-height">
             <Row xs={1} className="g-0"
-             key={this.props.isoCode} /* Recreate whenever key changes */
+            key={this.props.isoCode} /* Recreate whenever key changes */
             >
               <Col xs={6}>
                 <DateChooser
@@ -235,7 +235,7 @@ class InfoPanel extends React.PureComponent {
               />
             </Row>
           </Col>
-          <Col xs={3} md={2} lg={3} className="row-height">
+          <Col xs={{span: 6, order: 3}} md={{span: 2, order: 3}} lg={{span: 3, order: 3}} className="row-height">
             <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
               <CounterfactualStory
                 dateStart={this.state.dateModelStart}

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -18,7 +18,6 @@ import styles from "../css/Common.module.css";
 
 const propTypes = exact({
   isoCode: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired,
 });
 
 const defaultProps = {};
@@ -185,7 +184,7 @@ class InfoPanel extends React.PureComponent {
     return (
       <Container fluid>
         <Row className={`${styles.full_available_height} g-0`}>
-          <Col xs={3} md={2} lg={3} className={"row-height"}>
+          <Col xs={3} md={2} lg={3} className="row-height">
             <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
               <CountryDates
                 countryName={this.state.countryName}
@@ -203,7 +202,7 @@ class InfoPanel extends React.PureComponent {
               />
             </Row>
           </Col>
-          <Col xs={6} md={8} lg={6} className={"row-height"}>
+          <Col xs={6} md={8} lg={6} className="row-height">
             <Row xs={1} className="g-0"
              key={this.props.isoCode} /* Recreate whenever key changes */
             >

--- a/frontend/src/components/InfoPanel.jsx
+++ b/frontend/src/components/InfoPanel.jsx
@@ -178,13 +178,18 @@ class InfoPanel extends React.PureComponent {
   render() {
     // If there is country selected then return an empty <div>
     if (this.props.isoCode == null) {
-      return <div></div>
+      return <div></div>;
     }
     // Otherwise return the InfoPanel container
     return (
       <Container fluid>
         <Row className={`${styles.full_available_height} g-0`}>
-          <Col xs={{span: 6, order: 2}} md={{span: 2, order: 1}} lg={{span: 3, order: 1}} className="row-height">
+          <Col
+            xs={{ span: 6, order: 2 }}
+            md={{ span: 2, order: 1 }}
+            lg={{ span: 3, order: 1 }}
+            className="row-height"
+          >
             <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
               <CountryDates
                 countryName={this.state.countryName}
@@ -202,9 +207,16 @@ class InfoPanel extends React.PureComponent {
               />
             </Row>
           </Col>
-          <Col xs={{span: 12, order: 1}} md={{span: 8, order: 2}} lg={{span: 6, order: 2}} className="row-height">
-            <Row xs={1} className="g-0"
-            key={this.props.isoCode} /* Recreate whenever key changes */
+          <Col
+            xs={{ span: 12, order: 1 }}
+            md={{ span: 8, order: 2 }}
+            lg={{ span: 6, order: 2 }}
+            className="row-height"
+          >
+            <Row
+              xs={1}
+              className="g-0"
+              key={this.props.isoCode} /* Recreate whenever key changes */
             >
               <Col xs={6}>
                 <DateChooser
@@ -230,12 +242,21 @@ class InfoPanel extends React.PureComponent {
                 dateFinal={this.state.dateModelEnd}
                 dateFirstRestrictionsReal={this.state.dateFirstRestrictionsReal}
                 dateLockdownReal={this.state.dateLockdownReal}
-                dateFirstRestrictionsCounterfactual={this.state.dateFirstRestrictionsCounterfactual}
-                dateLockdownCounterfactual={this.state.dateLockdownCounterfactual}
+                dateFirstRestrictionsCounterfactual={
+                  this.state.dateFirstRestrictionsCounterfactual
+                }
+                dateLockdownCounterfactual={
+                  this.state.dateLockdownCounterfactual
+                }
               />
             </Row>
           </Col>
-          <Col xs={{span: 6, order: 3}} md={{span: 2, order: 3}} lg={{span: 3, order: 3}} className="row-height">
+          <Col
+            xs={{ span: 6, order: 3 }}
+            md={{ span: 2, order: 3 }}
+            lg={{ span: 3, order: 3 }}
+            className="row-height"
+          >
             <Row xs={1} className={`${styles.contents_padded_lg} g-0`}>
               <CounterfactualStory
                 dateStart={this.state.dateModelStart}

--- a/frontend/src/components/Loading.jsx
+++ b/frontend/src/components/Loading.jsx
@@ -9,7 +9,7 @@ const defaultProps = {};
 
 const Loading = () => {
   return (
-    <Row className={`${styles.spinners} flex-grow-1`}>
+    <Row className={`${styles.spinners} flex-grow-1 g-0`}>
       <Spinner animation="grow" variant="success" role="status" />
       <Spinner animation="grow" variant="danger" role="status" />
       <Spinner animation="grow" variant="info" role="status" />

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -75,7 +75,7 @@ class MainGrid extends React.PureComponent {
       );
     }
     return (
-      <Container fluid className={styles.full_screen}>
+      <Container fluid className={styles.full_screen} id="bootstrap-overrides">
         <Row style={{ height: this.state.heightHeader }}>
           <HeaderPanel />
         </Row>

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -95,14 +95,7 @@ class MainGrid extends React.PureComponent {
           </Col>
         </Row>
         <Row style={{ height: this.state.heightInfoPanel }} className="g-0">
-          {!this.state.isoCode ? (
-            <div></div>
-          ) : (
-            <InfoPanel
-              isoCode={this.state.isoCode}
-              height={this.state.heightInfoPanel}
-            />
-          )}
+          <InfoPanel isoCode={this.state.isoCode}/>
         </Row>
       </Container>
     );

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -76,21 +76,21 @@ class MainGrid extends React.PureComponent {
     }
     return (
       <Container fluid className={styles.full_screen} id="bootstrap-overrides">
-        <Row style={{ height: this.state.heightHeader }}>
+        <Row style={{ height: this.state.heightHeader }} className="g-0">
           <HeaderPanel />
         </Row>
         <Row style={{ height: this.state.heightMap }} className="g-0">
-          <Col xs={11}>
+          <Col xs={9} md={11}>
             <WorldMap
               countries={this.state.countries}
               onCountrySelect={this.handleCountryChange}
             />
           </Col>
-          <Col xs={1}>
+          <Col xs={3} md={1}>
             <Legend />
           </Col>
         </Row>
-        <Row style={{ height: this.state.heightHistogram }}>
+        <Row style={{ height: this.state.heightHistogram }} className="g-0">
           {!this.state.isoCode ? (
             <Loading />
           ) : (

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -77,7 +77,11 @@ class MainGrid extends React.PureComponent {
         </Container>
       );
     }
-    const heightWorldMap = this.toStr(100 - this.toNum(this.state.heightHeader) - this.toNum(this.state.heightInfoPanel));
+    const heightWorldMap = this.toStr(
+      100 -
+        this.toNum(this.state.heightHeader) -
+        this.toNum(this.state.heightInfoPanel)
+    );
     return (
       <Container fluid className={styles.full_screen} id="bootstrap-overrides">
         <Row style={{ height: this.state.heightHeader }} className="g-0">
@@ -95,7 +99,7 @@ class MainGrid extends React.PureComponent {
           </Col>
         </Row>
         <Row style={{ height: this.state.heightInfoPanel }} className="g-0">
-          <InfoPanel isoCode={this.state.isoCode}/>
+          <InfoPanel isoCode={this.state.isoCode} />
         </Row>
       </Container>
     );

--- a/frontend/src/components/MainGrid.jsx
+++ b/frontend/src/components/MainGrid.jsx
@@ -24,9 +24,8 @@ class MainGrid extends React.PureComponent {
       countries: [],
       defaultEndDate: "2020-07-06",
       isoCode: null,
-      heightHeader: "12vh",
-      heightMap: "87vh",
-      heightHistogram: "0vh",
+      heightHeader: "10vh",
+      heightInfoPanel: "0vh",
     };
 
     // Bind functions that need to use `this`
@@ -45,25 +44,29 @@ class MainGrid extends React.PureComponent {
     }
   }
 
+  // Convert between height in 'vh' units and the numerical value
+  toNum(value) {
+    return Number(value.replace("vh", ""));
+  }
+  toStr(value) {
+    return `${value}vh`;
+  }
+
   // Update the state for a new country
   handleCountryChange(iso_code, clickable) {
-    var isoCode, heightHistogram;
     if (iso_code === this.state.isoCode || !clickable) {
       console.log(`Setting currently selected country to none`);
-      isoCode = null;
-      heightHistogram = 0;
+      this.setState({
+        isoCode: null,
+        heightInfoPanel: `0vh`,
+      });
     } else {
       console.log(`Setting currently selected country to ${iso_code}`);
-      isoCode = iso_code;
-      heightHistogram = 35;
+      this.setState({
+        isoCode: iso_code,
+        heightInfoPanel: `35vh`,
+      });
     }
-    const heightMap =
-      100 - heightHistogram - Number(this.state.heightHeader.replace("vh", ""));
-    this.setState({
-      isoCode: isoCode,
-      heightMap: `${heightMap}vh`,
-      heightHistogram: `${heightHistogram}vh`,
-    });
   }
 
   render() {
@@ -74,12 +77,13 @@ class MainGrid extends React.PureComponent {
         </Container>
       );
     }
+    const heightWorldMap = this.toStr(100 - this.toNum(this.state.heightHeader) - this.toNum(this.state.heightInfoPanel));
     return (
       <Container fluid className={styles.full_screen} id="bootstrap-overrides">
         <Row style={{ height: this.state.heightHeader }} className="g-0">
           <HeaderPanel />
         </Row>
-        <Row style={{ height: this.state.heightMap }} className="g-0">
+        <Row style={{ height: heightWorldMap }} className="g-0">
           <Col xs={9} md={11}>
             <WorldMap
               countries={this.state.countries}
@@ -90,13 +94,13 @@ class MainGrid extends React.PureComponent {
             <Legend />
           </Col>
         </Row>
-        <Row style={{ height: this.state.heightHistogram }} className="g-0">
+        <Row style={{ height: this.state.heightInfoPanel }} className="g-0">
           {!this.state.isoCode ? (
-            <Loading />
+            <div></div>
           ) : (
             <InfoPanel
               isoCode={this.state.isoCode}
-              height={this.state.heightHistogram}
+              height={this.state.heightInfoPanel}
             />
           )}
         </Row>

--- a/frontend/src/css/Common.module.css
+++ b/frontend/src/css/Common.module.css
@@ -1,12 +1,21 @@
-.card {
-  margin: 1%;
-}
-
 .contents_centered {
   align-items: center;
   display: flex;
   flex-direction: column;
+  height: 100%;
   justify-content: center;
+}
+
+.contents_padded_lg {
+  padding: 5%;
+}
+
+.contents_padded_md {
+  padding: 2%;
+}
+
+.contents_padded_sm {
+  padding: 1%;
 }
 
 .full_available_width {
@@ -25,7 +34,7 @@
   height: 100vh;
   margin: 0;
   padding: 0;
-  width: 100vw;
+  width: 100%;
 }
 
 .space_child_columns {

--- a/frontend/src/css/Common.module.css
+++ b/frontend/src/css/Common.module.css
@@ -1,5 +1,5 @@
 .card {
-  margin: 1vh;
+  margin: 1%;
 }
 
 .contents_centered {
@@ -11,6 +11,10 @@
 
 .full_available_width {
   width: 100%;
+}
+
+.fixed_width_large {
+  width: 90%;
 }
 
 .full_available_height {

--- a/frontend/src/css/Common.module.css
+++ b/frontend/src/css/Common.module.css
@@ -9,13 +9,6 @@
   justify-content: center;
 }
 
-.contents_spaced {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-evenly;
-}
-
 .full_available_width {
   width: 100%;
 }
@@ -28,6 +21,21 @@
   height: 100vh;
   margin: 0;
   padding: 0;
+  width: 100vw;
+}
+
+.space_child_columns {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}
+
+.space_child_rows {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
 }
 
 .spacing_vertical {

--- a/frontend/src/css/DateChooser.module.css
+++ b/frontend/src/css/DateChooser.module.css
@@ -1,3 +1,3 @@
-.centered_text {
+.caption {
   text-align: center;
 }

--- a/frontend/src/css/DateChooser.module.css
+++ b/frontend/src/css/DateChooser.module.css
@@ -1,3 +1,4 @@
 .caption {
+  margin: 0;
   text-align: center;
 }

--- a/frontend/src/css/HeaderPanel.module.css
+++ b/frontend/src/css/HeaderPanel.module.css
@@ -1,3 +1,0 @@
-.logo {
-  padding: 1vh;
-}

--- a/frontend/src/css/Histogram.module.css
+++ b/frontend/src/css/Histogram.module.css
@@ -1,0 +1,3 @@
+.loading {
+  padding-top: 20%
+}

--- a/frontend/src/css/Histogram.module.css
+++ b/frontend/src/css/Histogram.module.css
@@ -1,3 +1,3 @@
 .loading {
-  padding-top: 20%
+  padding-top: 20%;
 }

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -3,3 +3,10 @@ html {
   margin: 0;
   padding: 0;
 }
+
+/* Add responsive text sizes */
+@media (max-width: 576px) {
+  #bootstrap-overrides { font-size: calc(0.25 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides .btn { font-size: calc(0.25 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides .h5 { font-size: calc(1.25 * 0.25 * (100% + 1vw + 1vh)); }
+}

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -13,8 +13,3 @@ html {
   #bootstrap-overrides .recharts-text { font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh)); }
   #bootstrap-overrides .recharts-label { font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh)); }
 }
-
-#bootstrap-overrides .col-3 .col-6 {
-  background-color: lightcyan;
-  outline: 1px solid gray;
-}

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -6,7 +6,15 @@ html {
 
 /* Add responsive text sizes */
 @media (max-width: 576px) {
-  #bootstrap-overrides { font-size: calc(0.25 * (100% + 1vw + 1vh)); }
-  #bootstrap-overrides .btn { font-size: calc(0.25 * (100% + 1vw + 1vh)); }
-  #bootstrap-overrides .h5 { font-size: calc(1.25 * 0.25 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides { font-size: calc(0.22 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides .btn { font-size: calc(0.22 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides .card-body { padding: 0; }
+  #bootstrap-overrides .h5 { font-size: calc(1.5 * 0.22 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides .recharts-text { font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides .recharts-label { font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh)); }
+}
+
+#bootstrap-overrides .col-3 .col-6 {
+  background-color: lightcyan;
+  outline: 1px solid gray;
 }

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -6,10 +6,22 @@ html {
 
 /* Add responsive text sizes */
 @media (max-width: 576px) {
-  #bootstrap-overrides { font-size: calc(0.22 * (100% + 1vw + 1vh)); }
-  #bootstrap-overrides .btn { font-size: calc(0.22 * (100% + 1vw + 1vh)); }
-  #bootstrap-overrides .card-body { padding: 0; }
-  #bootstrap-overrides .h5 { font-size: calc(1.5 * 0.22 * (100% + 1vw + 1vh)); }
-  #bootstrap-overrides .recharts-text { font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh)); }
-  #bootstrap-overrides .recharts-label { font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh)); }
+  #bootstrap-overrides {
+    font-size: calc(0.22 * (100% + 1vw + 1vh));
+  }
+  #bootstrap-overrides .btn {
+    font-size: calc(0.22 * (100% + 1vw + 1vh));
+  }
+  #bootstrap-overrides .card-body {
+    padding: 0;
+  }
+  #bootstrap-overrides .h5 {
+    font-size: calc(1.5 * 0.22 * (100% + 1vw + 1vh));
+  }
+  #bootstrap-overrides .recharts-text {
+    font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh));
+  }
+  #bootstrap-overrides .recharts-label {
+    font-size: calc(0.75 * 0.22 * (100% + 1vw + 1vh));
+  }
 }


### PR DESCRIPTION
Updated the design to change on different screen sizes. Major differences are:

## Summary
- width of columns in HeaderPanel, main map/legend panel and InfoPanel
- text sizes on small screens
- reflow of InfoPanel on small screens with the info cards moving underneath the histogram
- fixed margins/padding to ensure that different elements are cleanly separated
- removed default fixed-width offsets for x and y axes of histogram

## Screenshots
I've tested on the most common screen sizes which are:

### 1920×1080 (8.89%)
<img width="1924" alt="1920x1080" src="https://user-images.githubusercontent.com/3502751/124381451-9498c600-dcba-11eb-8257-a6b59c2f87b5.png">

### 1366×768 (8.44%)
<img width="1369" alt="1366×768" src="https://user-images.githubusercontent.com/3502751/124381454-9a8ea700-dcba-11eb-8dd4-a3fc825293a8.png">

### 360×640 (7.28%)
<img width="363" alt="360x640" src="https://user-images.githubusercontent.com/3502751/124381457-9f535b00-dcba-11eb-9220-f5c2ca797292.png">

### 414×896 (4.58%)
<img width="419" alt="414x896" src="https://user-images.githubusercontent.com/3502751/124381463-a4b0a580-dcba-11eb-9925-a4ddfbe249ed.png">

### 1536×864 (3.88%)
<img width="1539" alt="1536x864" src="https://user-images.githubusercontent.com/3502751/124381469-a9755980-dcba-11eb-91fc-3d99840b01a2.png">

### 375×667 (3.75%)
<img width="381" alt="375x667" src="https://user-images.githubusercontent.com/3502751/124381475-af6b3a80-dcba-11eb-98b0-e8a7ff2a348b.png">

Closes #88